### PR TITLE
docs: rewrite README + crate-level lib.rs + beef up thin module headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,49 +2,19 @@
 
 Type-safe Rust client for the [Anthropic API](https://docs.anthropic.com/).
 
-Sibling project to `claude-wrapper`. That one wraps the `claude` CLI; this
-one wraps the HTTP API. They do not depend on each other.
+[![Crates.io](https://img.shields.io/crates/v/claude-api.svg)](https://crates.io/crates/claude-api)
+[![Documentation](https://docs.rs/claude-api/badge.svg)](https://docs.rs/claude-api)
+[![CI](https://github.com/joshrotenberg/claude-api/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/claude-api/actions/workflows/ci.yml)
+[![License](https://img.shields.io/crates/l/claude-api.svg)](https://github.com/joshrotenberg/claude-api#license)
+[![MSRV](https://img.shields.io/crates/msrv/claude-api.svg)](https://github.com/joshrotenberg/claude-api)
 
-## Status
+## Workspace
 
-**v0.5 -- full API surface.** Every documented Anthropic endpoint is
-now reachable through a typed Rust namespace:
-
-- **Messages, Models, Batches, Files, count_tokens, streaming**
-  (carried forward from v0.1-v0.4)
-- **Admin API** (27 endpoints): organization, invites, users,
-  workspaces + members, api_keys, usage_report, cost_report,
-  rate_limits
-- **Skills API** (8 endpoints): full CRUD + skill versions, multipart
-  upload
-- **User Profiles API** (5 endpoints) including the enrollment-URL flow
-- **Managed Agents preview**: sessions, agents, environments, vaults
-  + credentials, memory_stores + memories + memory_versions, session
-  resources, events (list/send/SSE stream), and the multi-agent
-  threads endpoints
-- **Bedrock auth** via a sigv4 `RequestSigner` extension point
-- **Typed `BetaHeader` enum** for the 23 canonical `anthropic-beta`
-  values, with `Other(String)` forward-compat fallthrough
-- **Live-test harness** with 15 record-or-replay tests covering the
-  cheap and read-only surfaces; cassettes committed for free CI replay
-- **Spec-diff tooling** that compares every public Rust struct to its
-  OpenAPI schema field-by-field
-
-Carried forward from v0.4 and earlier:
-
-- **v0.4** Agent-loop guardrails (parallel dispatch + cost budget +
-  cancellation), streaming callbacks, `dry_run`, `cost_preview`,
-  `#[derive(Tool)]` proc macro
-- **v0.3** Typed `Citation` enum, context compaction, full Batches
-  API, Files API beta, typed `BuiltinTool` wrappers
-- **v0.2** `ToolRegistry` + agent loop, `Conversation` helper,
-  `PricingTable`, vision and document blocks, prompt-cache sugar,
-  sync feature
-- **v0.1** Messages + Models endpoints, forward-compatible serde,
-  retry policy that honors `Retry-After`, `request-id` propagation,
-  structured `tracing`
-
-See [`CHANGELOG.md`](CHANGELOG.md) for per-version detail.
+| Crate | Description |
+|-------|-------------|
+| [`claude-api`](crates/claude-api/) | The SDK |
+| [`claude-api-derive`](crates/claude-api-derive/) | `#[derive(Tool)]` proc-macro (re-exported via the `derive` feature) |
+| [`claude-api-test`](crates/claude-api-test/) | Cassette-based replay + recorder for integration tests |
 
 ## Quick start
 
@@ -85,122 +55,88 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-See [`examples/`](examples/) for streaming, streaming-with-callbacks,
-tool use, derived tools, vision, document, conversation, and the agent
-loop.
+See [`crates/claude-api/examples/`](crates/claude-api/examples/) for
+streaming, streaming-with-callbacks, tool use, derived tools, vision,
+document, conversation, and the agent loop.
 
-## Why another Anthropic Rust client?
+## API surface
 
-- **Forward-compatible by design.** New `ContentBlock`, `StreamEvent`,
-  `ContentDelta`, `Citation`, and `BuiltinTool` variants from the API are
-  preserved as raw JSON via an `Other(Value)` arm rather than breaking
-  older SDK versions. New `type` tags round-trip byte-for-byte. No other
-  Rust crate (and no official SDK in any language) does this.
+Every documented Anthropic endpoint is reachable through a typed
+namespace handle off [`Client`]:
 
-  **Upgrade contract**: when a server-side `type` tag that previously
-  fell through to `Other` becomes a recognized `Known` variant in a new
-  release, that's a **minor** version bump. Code that pattern-matched
-  on `Other(v) if v["type"] == "thinking"` will silently stop matching
-  -- the value now arrives as `Known(KnownBlock::Thinking { .. })`.
-  When you bump claude-api, sweep your `Other` matches and route the
-  newly-known variants explicitly. Releases that promote variants will
-  call them out in the changelog.
-- **`Retry-After` honored.** Most existing Rust crates for the Anthropic
-  API ignore the header. This one respects it, with configurable
-  `RetryPolicy { max_attempts, initial_backoff, max_backoff, jitter,
-  respect_retry_after }`.
-- **Cost-aware by default.** `PricingTable` ships with bundled rates for
-  current models; `Conversation::cost(&PricingTable)` and
-  `cost_preview(&request, &pricing)` give you live and pre-flight USD
-  numbers. Agent loop accepts a `cost_budget` that aborts a run before
-  the next iteration if a cap is exceeded.
-- **Operational quality from day one.** `request-id` is surfaced on every
-  error (critical for support tickets), `ApiKey: Debug` redacts the
-  secret, base-URL override makes wiremock-based testing the default
-  story, structured `tracing` spans on every request and retry.
-- **Tools you can derive.** `#[derive(Tool)]` on a struct generates the
-  `Tool` impl from the struct's `JsonSchema` and an inherent
-  `async fn run(self)`. No string-literal schemas, no boilerplate `name`
-  / `description` overrides unless you want them.
-- **No surprise abstractions.** No prompt-template DSL, no multi-provider
-  routing, no response caching, no bundled CLI. If you want those, use a
-  different crate.
+| Namespace | Endpoints | Feature flag |
+|-----------|-----------|--------------|
+| `client.messages()` | create, count_tokens, streaming | (default) |
+| `client.models()` | list, get | (default) |
+| `client.batches()` | create, get, list, cancel, delete, results, wait_for | (default) |
+| `client.files()` | upload, get, list, delete, download | (default) |
+| `client.skills()` | full CRUD across skills + skill versions | `skills` |
+| `client.user_profiles()` | create, list, get, update, create-enrollment-url | `user-profiles` |
+| `client.managed_agents()` | sessions, agents, environments, vaults + credentials, memory_stores + memories + versions, resources, threads, events | `managed-agents-preview` |
+| `client.admin()` | organizations, invites, users, workspaces + members, api_keys, usage_report, cost_report, rate_limits | `admin` |
+
+## Capabilities
+
+- **Forward-compatible types**. `ContentBlock`, `StreamEvent`,
+  `ContentDelta`, `Citation`, `BuiltinTool`, `BetaHeader`,
+  `SessionResource` and similar wrapper enums round-trip unknown
+  variants through an `Other(Value)` arm. New API variants don't
+  break older SDK builds.
+- **`Retry-After` honored**. Configurable
+  `RetryPolicy { max_attempts, initial_backoff, max_backoff,
+  jitter, respect_retry_after }`.
+- **`request-id` on every error**. Surfaced as
+  `Error::request_id() -> Option<&str>`.
+- **Streaming** with typed `EventStream` plus optional `on_text_delta` /
+  `on_tool_use_complete` / `on_thinking_delta` / `on_message_stop` /
+  `on_error` callback hooks.
+- **Tool dispatch** with `ToolRegistry`, parallel-by-default
+  invocation, mid-stream approval gates, cumulative cost budget,
+  cancellation token.
+- **`#[derive(Tool)]`** proc-macro generates the `Tool` impl from a
+  struct's `JsonSchema` (under the `derive` feature).
+- **`Conversation`** multi-turn helper with cumulative usage and
+  optional context compaction.
+- **`PricingTable`** with bundled per-model rates plus
+  `cost_preview()` for pre-flight USD estimates.
+- **`dry_run` mode** renders the would-be HTTP request as
+  `DryRun { method, url, headers, body }` plus `to_curl()` /
+  `to_curl_with_key()` helpers.
+- **Auth**: API key (default), AWS Bedrock sigv4 signer (`bedrock`
+  feature), pluggable via the `RequestSigner` trait.
+- **Sync + async**: same surface, blocking variants under the `sync`
+  feature.
+- **Structured `tracing`** spans + events on every request and
+  retry. Zero plumbing required.
+- **Cassette-based integration tests** via
+  [`claude-api-test`](crates/claude-api-test/) -- record once
+  against the real API, replay deterministically in CI.
 
 ## Feature flags
 
-| Flag                       | Default | Adds                                                       |
-| -------------------------- | ------- | ---------------------------------------------------------- |
-| `async`                    | yes     | Async client (tokio + reqwest)                             |
-| `rustls`                   | yes     | rustls TLS backend                                         |
-| `streaming`                | yes     | SSE streaming + `EventStream::aggregate` + callback hooks  |
-| `sync`                     |         | Blocking client (reqwest blocking)                         |
-| `native-tls`               |         | native-tls backend instead of rustls                       |
-| `schemars-tools`           |         | `Tool::from_schemars::<T: JsonSchema>` ctor                |
-| `derive`                   |         | `#[derive(Tool)]` (pulls in `claude-api-derive`)           |
-| `pricing`                  |         | `PricingTable` + cost calculation + `cost_preview`         |
-| `conversation`             |         | Multi-turn `Conversation` helper                           |
-| `bedrock`                  |         | AWS sigv4 `BedrockSigner` (custom auth signer)             |
-| `vertex`                   |         | GCP Vertex auth -- v0.6+ (placeholder; not wired yet)      |
-| `admin`                    |         | Admin API (organizations, users, workspaces, etc.)         |
-| `skills`                   |         | Skills API (CRUD + versions, multipart upload)             |
-| `user-profiles`            |         | User Profiles API + enrollment-URL flow                    |
-| `managed-agents-preview`   |         | Managed Agents preview (sessions, agents, vaults, ...)     |
+| Flag | Default | Adds |
+|------|---------|------|
+| `async` | yes | Async client (tokio + reqwest) |
+| `rustls` | yes | rustls TLS backend |
+| `streaming` | yes | SSE streaming + `EventStream::aggregate` + callback hooks |
+| `sync` |  | Blocking client (reqwest blocking) |
+| `native-tls` |  | native-tls instead of rustls |
+| `schemars-tools` |  | `Tool::from_schemars::<T: JsonSchema>` constructor |
+| `derive` |  | `#[derive(Tool)]` (pulls in `claude-api-derive`) |
+| `pricing` |  | `PricingTable` + cost calculation + `cost_preview` |
+| `conversation` |  | Multi-turn `Conversation` helper |
+| `bedrock` |  | AWS sigv4 `BedrockSigner` |
+| `vertex` |  | (placeholder, not yet wired -- see [#6](https://github.com/joshrotenberg/claude-api/issues/6)) |
+| `admin` |  | Admin API |
+| `skills` |  | Skills API |
+| `user-profiles` |  | User Profiles API |
+| `managed-agents-preview` |  | Managed Agents preview |
 
 Disable defaults if you only want the type definitions:
 
 ```toml
 claude-api = { version = "0.5", default-features = false }
 ```
-
-## Tool example with `#[derive(Tool)]`
-
-```rust
-use claude_api::derive::Tool;
-use claude_api::tool_dispatch::{ToolError, ToolRegistry};
-use schemars::JsonSchema;
-use serde::Deserialize;
-use serde_json::{json, Value};
-
-/// Get the current weather for a city.
-#[derive(Deserialize, JsonSchema, Tool)]
-struct GetWeather {
-    /// City to look up.
-    city: String,
-}
-
-impl GetWeather {
-    async fn run(self) -> Result<Value, ToolError> {
-        Ok(json!({"temp_f": 72, "city": self.city}))
-    }
-}
-
-let mut registry = ToolRegistry::new();
-registry.register_tool(GetWeather::tool());
-```
-
-The tool name (`get_weather`) is derived from the struct name; the
-description from the doc comment. Override either with
-`#[tool(name = "...", description = "...")]`.
-
-## Roadmap
-
-- **v0.1** Messages, Models, streaming, retry, forward-compat
-- **v0.2** `ToolRegistry` + agent loop, `Conversation` helper,
-  `PricingTable`, vision and document blocks, prompt-cache sugar, sync
-  feature
-- **v0.3** Batches (with poller), Files API, citations, typed built-in
-  tool wrappers, context compaction
-- **v0.4** Agent-loop guardrails (parallel dispatch + cost budget +
-  cancellation), streaming callbacks, `dry_run`, `cost_preview`,
-  `#[derive(Tool)]` proc macro, mid-stream tool approval gates,
-  record/replay test harness, Bedrock auth (sigv4 signer)
-- **v0.5** Admin / Skills / User Profiles / Managed Agents preview
-  endpoints, typed `BetaHeader` enum, spec-diff tooling, live-test
-  cassettes
-- **v0.6+** Vertex AI auth, Tower `Service` -> `Tool` integration,
-  typed promotions for `stop_details` / `context_management` /
-  `ModelCapabilities`, streaming-SSE cassette recording, vault
-  credential live tests
 
 ## Anti-goals
 
@@ -215,9 +151,16 @@ crate":
 - Embedding API (Anthropic does not have one; do not stub)
 - Legacy `/v1/complete` Completions API
 
+## Resources
+
+- [Examples](crates/claude-api/examples/)
+- [Changelog](crates/claude-api/CHANGELOG.md)
+- [Open issues](https://github.com/joshrotenberg/claude-api/issues) --
+  roadmap items, planned work, known gaps
+
 ## MSRV
 
-Rust 1.82 or later.
+Rust 1.90 or later. Edition 2024.
 
 ## License
 

--- a/crates/claude-api/src/error.rs
+++ b/crates/claude-api/src/error.rs
@@ -1,4 +1,54 @@
 //! Error type, result alias, and wire-format error payload.
+//!
+//! Every endpoint method returns [`Result<T>`](Result) where the
+//! error variant is [`Error`]. The error carries:
+//!
+//! - **HTTP status** (when the API responded with one) via
+//!   [`Error::status`]
+//! - **`request-id`** (always populated when the server sent one)
+//!   via [`Error::request_id`] -- this is the field to include in
+//!   support tickets
+//! - **Retry classification** via [`Error::is_retryable`] -- the
+//!   [`retry::RetryPolicy`](crate::retry::RetryPolicy) layer uses
+//!   the same logic
+//! - **`Retry-After` honoring** via [`Error::retry_after`] -- the
+//!   parsed `Retry-After` header (in seconds), used by the retry
+//!   layer to wait before the next attempt
+//! - **Structured kind** via [`ApiErrorKind`] for documented API
+//!   error types (rate-limit, authentication, not-found, etc.)
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use claude_api::{Client, messages::CreateMessageRequest, types::ModelId};
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = Client::new("sk-ant-...");
+//! let req = CreateMessageRequest::builder()
+//!     .model(ModelId::SONNET_4_6)
+//!     .max_tokens(8)
+//!     .user("hi")
+//!     .build()?;
+//!
+//! match client.messages().create(req).await {
+//!     Ok(resp) => println!("ok: {}", resp.id),
+//!     Err(e) if e.is_retryable() => {
+//!         // The retry layer already retried; if we're here, attempts
+//!         // were exhausted.
+//!         eprintln!("gave up after retries: {} (request_id={:?})",
+//!                   e, e.request_id());
+//!     }
+//!     Err(e) => {
+//!         // Permanent error -- 4xx, deserialization, signing, etc.
+//!         eprintln!("error: {} (request_id={:?})",
+//!                   e, e.request_id());
+//!     }
+//! }
+//! # Ok(()) }
+//! ```
+//!
+//! Variants tied to optional features (`async`/`sync` for
+//! [`Error::Network`], `streaming` for [`Error::Stream`]) are
+//! conditionally compiled out when those features are disabled.
 
 use std::time::Duration;
 

--- a/crates/claude-api/src/lib.rs
+++ b/crates/claude-api/src/lib.rs
@@ -1,6 +1,117 @@
-//! Type-safe Rust client for the Anthropic API.
+//! Type-safe Rust client for the [Anthropic API](https://docs.anthropic.com/).
 //!
-//! See the [crate README](https://github.com/joshrotenberg/claude-api) for an overview.
+//! Every documented Anthropic endpoint is reachable through a typed
+//! namespace handle off [`Client`]. Forward-compatible by design --
+//! unknown content blocks, stream events, citations, and similar
+//! discriminated unions round-trip through `Other(Value)` arms so
+//! new server-side variants don't break older SDK builds.
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use claude_api::{Client, messages::CreateMessageRequest, types::ModelId};
+//!
+//! # async fn run() -> Result<(), claude_api::Error> {
+//! let client = Client::new(std::env::var("ANTHROPIC_API_KEY").unwrap());
+//!
+//! let resp = client
+//!     .messages()
+//!     .create(
+//!         CreateMessageRequest::builder()
+//!             .model(ModelId::SONNET_4_6)
+//!             .max_tokens(256)
+//!             .user("Hello!")
+//!             .build()?,
+//!     )
+//!     .await?;
+//!
+//! for block in &resp.content {
+//!     if let claude_api::messages::ContentBlock::Known(
+//!         claude_api::messages::KnownBlock::Text { text, .. },
+//!     ) = block
+//!     {
+//!         println!("{text}");
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Module map
+//!
+//! Endpoints are organized by Anthropic resource. Each namespace
+//! handle is reached via a method on [`Client`]:
+//!
+//! | Module | Namespace | Default? |
+//! |---|---|---|
+//! | [`messages`] | `client.messages()` | yes |
+//! | [`models`] | `client.models()` | yes |
+//! | [`batches`] | `client.batches()` | yes |
+//! | [`files`] | `client.files()` | yes |
+//! | [`skills`] | `client.skills()` | feature `skills` |
+//! | [`user_profiles`] | `client.user_profiles()` | feature `user-profiles` |
+//! | [`managed_agents`] | `client.managed_agents()` | feature `managed-agents-preview` |
+//! | [`admin`] | `client.admin()` | feature `admin` |
+//!
+//! Cross-cutting machinery:
+//!
+//! | Module | Purpose |
+//! |---|---|
+//! | [`auth`] | API-key wrapper + [`auth::RequestSigner`] trait |
+//! | [`bedrock`] | AWS sigv4 [`bedrock::BedrockSigner`] (feature `bedrock`) |
+//! | [`beta`] | [`BetaHeader`] open-string enum for the `anthropic-beta` header |
+//! | [`retry`] | [`retry::RetryPolicy`] honoring `Retry-After` |
+//! | [`error`] | [`Error`] with `request_id`, retry classification |
+//! | [`pagination`] | [`Paginated`](pagination::Paginated) and [`PaginatedNextPage`](pagination::PaginatedNextPage) |
+//! | [`types`] | Shared primitives: [`ModelId`](types::ModelId), [`Role`](types::Role), [`Usage`](types::Usage), [`StopReason`](types::StopReason) |
+//! | [`conversation`] | Multi-turn helper with cumulative usage (feature `conversation`) |
+//! | [`tool_dispatch`] | [`ToolRegistry`](tool_dispatch::ToolRegistry), agent loop, parallel dispatch, approval gates |
+//! | [`pricing`] | [`PricingTable`](pricing::PricingTable) (feature `pricing`) |
+//! | [`cost_preview`] | Pre-flight USD estimates (features `async` + `pricing`) |
+//! | [`dry_run`] | Render the would-be HTTP request without sending |
+//! | [`sse`] | SSE wrapper used by streaming endpoints (feature `streaming`) |
+//!
+//! # Forward compatibility
+//!
+//! Every wire-level discriminated union has an `Other` arm:
+//!
+//! - [`messages::ContentBlock`] -- text / image / tool_use /
+//!   thinking / ... / `Other(Value)`
+//! - [`messages::KnownBlock`] -- the typed variants
+//! - [`messages::stream::StreamEvent`] -- SSE events
+//! - [`messages::citation::Citation`] -- citation kinds
+//! - [`BetaHeader`] -- known beta header values + `Other(String)`
+//!
+//! When Anthropic adds a new variant, your code that pattern-matches
+//! on `Known(...)` continues to compile; the new variant lands in
+//! `Other(...)` until you upgrade. See the **upgrade contract** in
+//! the README before bumping past a release that promotes an `Other`
+//! to `Known`.
+//!
+//! # Error handling
+//!
+//! All endpoint methods return [`Result<T>`](Result) where
+//! [`Error`] carries:
+//!
+//! - HTTP status (when the API responded)
+//! - `request-id` (always populated when the server sent one)
+//! - Retry classification (`is_retryable()`) and parsed
+//!   `Retry-After` (`retry_after()`)
+//! - Structured kind ([`error::ApiErrorKind`]) for known
+//!   error types
+//!
+//! The [`retry::RetryPolicy`] applied by the client respects
+//! `Retry-After` by default and uses jittered exponential backoff
+//! otherwise. Disable retries with `RetryPolicy::none()` if your
+//! caller wraps its own retry logic.
+//!
+//! # Observability
+//!
+//! Every HTTP request emits a `tracing` span at `debug` level with
+//! `method`, `path`, and `request_id` fields. Retries log at `warn`
+//! with `attempt`, `retry_in_ms`, and `status`. No env-var gating
+//! is required; install a `tracing-subscriber` to capture the
+//! events.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/crates/claude-api/src/lib.rs
+++ b/crates/claude-api/src/lib.rs
@@ -75,7 +75,7 @@
 //!
 //! Every wire-level discriminated union has an `Other` arm:
 //!
-//! - [`messages::ContentBlock`] -- text / image / tool_use /
+//! - [`messages::ContentBlock`] -- text / image / `tool_use` /
 //!   thinking / ... / `Other(Value)`
 //! - [`messages::KnownBlock`] -- the typed variants
 //! - [`messages::stream::StreamEvent`] -- SSE events

--- a/crates/claude-api/src/messages/mod.rs
+++ b/crates/claude-api/src/messages/mod.rs
@@ -1,4 +1,56 @@
-//! The Messages API: `create`, `create_stream`, `count_tokens`.
+//! The Messages API.
+//!
+//! The headline endpoint of the Anthropic API. Build a request via
+//! [`CreateMessageRequest::builder`], then send it through the
+//! [`Messages`] namespace handle obtained from
+//! [`Client::messages`](crate::Client::messages).
+//!
+//! # Endpoints
+//!
+//! | Method | Path | Function |
+//! |---|---|---|
+//! | `POST` | `/v1/messages` | [`Messages::create`] (non-streaming) |
+//! | `POST` | `/v1/messages` | [`Messages::create_stream`] (SSE) |
+//! | `POST` | `/v1/messages/count_tokens` | [`Messages::count_tokens`] |
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use claude_api::{Client, messages::CreateMessageRequest, types::ModelId};
+//! # async fn run() -> Result<(), claude_api::Error> {
+//! let client = Client::new("sk-ant-...");
+//! let resp = client.messages().create(
+//!     CreateMessageRequest::builder()
+//!         .model(ModelId::SONNET_4_6)
+//!         .max_tokens(256)
+//!         .system("Be concise.")
+//!         .user("What is the capital of France?")
+//!         .build()?,
+//! ).await?;
+//! # Ok(()) }
+//! ```
+//!
+//! # Module layout
+//!
+//! - [`request`] -- [`CreateMessageRequest`], [`CountTokensRequest`],
+//!   builders
+//! - [`response`] -- [`Message`], [`CountTokensResponse`],
+//!   [`ContainerInfo`]
+//! - [`content`] -- [`ContentBlock`] / [`KnownBlock`] union with
+//!   forward-compat fallthrough
+//! - [`stream`] -- [`StreamEvent`], [`ContentDelta`], the
+//!   `EventStream` aggregator + `on_*` callbacks
+//! - [`tools`] -- [`Tool`], [`BuiltinTool`], [`CustomTool`],
+//!   [`ToolChoice`]
+//! - [`cache`] -- [`CacheControl`] for prompt caching
+//! - [`thinking`] -- [`ThinkingConfig`] for extended thinking
+//! - [`mcp`] -- [`McpServerConfig`] for MCP server invocation
+//! - [`citation`] -- typed [`Citation`] enum
+//! - [`input`] -- [`MessageInput`], [`SystemPrompt`] helpers
+//! - [`metadata`] -- [`MessageMetadata`], [`RequestServiceTier`]
+//!
+//! For streaming, see [`stream`] for the wire-event types and
+//! [`api::Messages::create_stream`] for the namespace method.
 
 pub mod cache;
 pub mod citation;

--- a/crates/claude-api/src/models/mod.rs
+++ b/crates/claude-api/src/models/mod.rs
@@ -1,4 +1,33 @@
-//! The Models API: `list`, `list_all`, `get`.
+//! The Models API.
+//!
+//! Discover what models are available to your API key, with their
+//! capability matrix and per-model token limits.
+//!
+//! # Endpoints
+//!
+//! | Method | Path | Function |
+//! |---|---|---|
+//! | `GET` | `/v1/models` | [`Models::list`] (paginated) |
+//! | `GET` | `/v1/models` | [`Models::list_all`] (auto-paginates) |
+//! | `GET` | `/v1/models/{id}` | [`Models::get`] |
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use claude_api::{Client, models::ListModelsParams};
+//! # async fn run() -> Result<(), claude_api::Error> {
+//! let client = Client::new("sk-ant-...");
+//!
+//! // Iterate the full set transparently:
+//! for model in client.models().list_all().await? {
+//!     println!("{}: {}", model.id.as_str(), model.display_name);
+//! }
+//!
+//! // Or fetch one by ID:
+//! let m = client.models().get("claude-sonnet-4-6").await?;
+//! println!("{} (max input: {:?})", m.display_name, m.max_input_tokens);
+//! # Ok(()) }
+//! ```
 
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Closes #4. Partial #15 (the urgent crate-level pieces; per-module
headers for the remaining modules and the examples-to-doc-snippet
sync left for follow-up PRs, per the multi-pass plan in #15).

## README

Strip competitor positioning and \"why another Rust client\" framing
-- those live in \`CLAUDE.md\` (gitignored local context). Public
README is now pure factual:

- Badge row: crates.io / docs.rs / CI / license / MSRV
- Workspace crate table (claude-api, -derive, -test)
- Quick-start snippet
- API surface table (namespaces + feature-flag gates)
- Capability bullets (factual, no positioning)
- Feature flag matrix
- Anti-goals
- Pointers to examples / CHANGELOG / open issues
- License + MSRV

## Crate-level lib.rs

Replaces the one-line \"see README\" placeholder with a substantial
crate-level overview:

- One-paragraph orientation
- Quick-start example (\`no_run\`)
- Module map: namespace handles + cross-cutting machinery
- Forward-compat policy + the \`Other\` enum-arm contract
- Error-handling section (request_id, retry classification,
  Retry-After)
- Observability section (tracing spans/events)

## Module headers expanded (3 thinnest)

These were previously one-line placeholders:

- \`messages/mod.rs\` -- endpoint table, quick-start, module layout map
- \`models/mod.rs\` -- endpoint table, list/get example
- \`error.rs\` -- error-handling features with the retry-aware match
  pattern

## What's left of #15 (follow-ups)

Per the issue body's own multi-pass plan, the remaining work is:

- Per-module headers for the other ~20 modules (messages sub-modules,
  managed-agents sub-modules, admin sub-modules, tool_dispatch
  sub-modules, plus auth/bedrock/retry/sse/pagination/beta/cost_preview/dry_run)
- Examples-to-doc-snippet sync (every \`examples/*.rs\` should have a
  matching \`\`\`rust no_run\`\`\` snippet in the relevant module's
  doc-string)
- New examples for derive(Tool) end-to-end, Bedrock auth setup,
  managed-agents lifecycle, batches submit + wait + read

Splitting these out keeps the review surface manageable. Will open
follow-up PRs per module area once #4 lands.

## Test plan

- [x] \`RUSTDOCFLAGS=\"-D warnings -D rustdoc::broken-intra-doc-links
      -D rustdoc::redundant-explicit-links\" cargo doc --workspace
      --all-features --no-deps\` clean
- [x] \`cargo test --doc --workspace --all-features\` clean
- [x] \`cargo test --workspace --all-features --lib\`: 506 + all
      integration green
- [x] \`cargo fmt --check\` clean