### PR TITLE
chore: release v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "claude-api"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "claude-api-test"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "claude-api",

--- a/crates/claude-api-test/CHANGELOG.md
+++ b/crates/claude-api-test/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `claude-api-test` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and uses [Semantic Versioning](https://semver.org/).
 
+## [0.5.2](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.1...claude-api-test-v0.5.2) - 2026-05-01
+
+### Other
+
+- updated the following local packages: claude-api
+
 ## [0.5.1](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.0...claude-api-test-v0.5.1) - 2026-05-01
 
 ### Other

--- a/crates/claude-api-test/Cargo.toml
+++ b/crates/claude-api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-api-test"
-version = "0.5.1"
+version = "0.5.2"
 description = "Test utilities for claude-api: cassette-based replay of recorded HTTP exchanges"
 documentation = "https://docs.rs/claude-api-test"
 edition.workspace = true
@@ -21,7 +21,7 @@ reqwest = { workspace = true, features = ["rustls-tls"] }
 bytes = { workspace = true }
 
 [dev-dependencies]
-claude-api = { version = "0.5.1", path = "../claude-api", default-features = false, features = ["async", "rustls", "streaming", "skills", "user-profiles", "managed-agents-preview", "admin"] }
+claude-api = { version = "0.5.2", path = "../claude-api", default-features = false, features = ["async", "rustls", "streaming", "skills", "user-profiles", "managed-agents-preview", "admin"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 pretty_assertions = { workspace = true }
 

--- a/crates/claude-api/CHANGELOG.md
+++ b/crates/claude-api/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `claude-api`, `claude-api-derive`, and
 Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.2](https://github.com/joshrotenberg/claude-api/compare/v0.5.1...v0.5.2) - 2026-05-01
+
+### Fixed
+
+- remove git-cliff changelog regen + restore curated CHANGELOG ([#23](https://github.com/joshrotenberg/claude-api/pull/23))
+
+### Other
+
+- regenerate changelog ([#22](https://github.com/joshrotenberg/claude-api/pull/22))
+
 ## [0.5.1] -- 2026-05-01
 
 Documentation pass. No API changes.

--- a/crates/claude-api/Cargo.toml
+++ b/crates/claude-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-api"
-version = "0.5.1"
+version = "0.5.2"
 description = "Type-safe Rust client for the Anthropic API"
 keywords = ["anthropic", "claude", "api", "ai", "llm"]
 categories = ["api-bindings", "asynchronous"]


### PR DESCRIPTION



## 🤖 New release

* `claude-api`: 0.5.1 -> 0.5.2 (✓ API compatible changes)
* `claude-api-test`: 0.5.1 -> 0.5.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-api`

<blockquote>

## [0.5.2](https://github.com/joshrotenberg/claude-api/compare/v0.5.1...v0.5.2) - 2026-05-01

### Fixed

- remove git-cliff changelog regen + restore curated CHANGELOG ([#23](https://github.com/joshrotenberg/claude-api/pull/23))

### Other

- regenerate changelog ([#22](https://github.com/joshrotenberg/claude-api/pull/22))
</blockquote>

## `claude-api-test`

<blockquote>

## [0.5.2](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.1...claude-api-test-v0.5.2) - 2026-05-01

### Other

- updated the following local packages: claude-api
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).