### PR TITLE
chore: release v0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "claude-api"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "claude-api-test"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "claude-api",

--- a/crates/claude-api-test/CHANGELOG.md
+++ b/crates/claude-api-test/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `claude-api-test` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and uses [Semantic Versioning](https://semver.org/).
 
+## [0.5.3](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.2...claude-api-test-v0.5.3) - 2026-05-02
+
+### Added
+
+- *(live-tests)* add test stubs for user-profiles, skills write, batches completion, conversation, runner ([#36](https://github.com/joshrotenberg/claude-api/pull/36))
+- *(test)* SSE cassette recording and replay support ([#38](https://github.com/joshrotenberg/claude-api/pull/38))
+- *(models)* type-promote ModelInfo.capabilities ([#27](https://github.com/joshrotenberg/claude-api/pull/27))
+
+### Other
+
+- *(streaming)* record live cassette for messages.create_stream ([#39](https://github.com/joshrotenberg/claude-api/pull/39))
+
 ## [0.5.2](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.1...claude-api-test-v0.5.2) - 2026-05-01
 
 ### Other

--- a/crates/claude-api-test/Cargo.toml
+++ b/crates/claude-api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-api-test"
-version = "0.5.2"
+version = "0.5.3"
 description = "Test utilities for claude-api: cassette-based replay of recorded HTTP exchanges"
 documentation = "https://docs.rs/claude-api-test"
 edition.workspace = true
@@ -21,7 +21,7 @@ reqwest = { workspace = true, features = ["rustls-tls"] }
 bytes = { workspace = true }
 
 [dev-dependencies]
-claude-api = { version = "0.5.2", path = "../claude-api", default-features = false, features = ["async", "rustls", "streaming", "skills", "user-profiles", "managed-agents-preview", "admin", "conversation"] }
+claude-api = { version = "0.5.3", path = "../claude-api", default-features = false, features = ["async", "rustls", "streaming", "skills", "user-profiles", "managed-agents-preview", "admin", "conversation"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 pretty_assertions = { workspace = true }
 

--- a/crates/claude-api/CHANGELOG.md
+++ b/crates/claude-api/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `claude-api`, `claude-api-derive`, and
 Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.3](https://github.com/joshrotenberg/claude-api/compare/v0.5.2...v0.5.3) - 2026-05-02
+
+### Added
+
+- *(live-tests)* add test stubs for user-profiles, skills write, batches completion, conversation, runner ([#36](https://github.com/joshrotenberg/claude-api/pull/36))
+- *(vertex)* VertexSigner RequestSigner impl for GCP Vertex AI auth ([#37](https://github.com/joshrotenberg/claude-api/pull/37))
+- *(messages)* type-promote stop_details and context_management ([#35](https://github.com/joshrotenberg/claude-api/pull/35))
+- *(models)* type-promote ModelInfo.capabilities ([#27](https://github.com/joshrotenberg/claude-api/pull/27))
+- *(managed-agents)* wire research-preview header for outcomes ([#24](https://github.com/joshrotenberg/claude-api/pull/24))
+
+### Other
+
+- new examples + module header upgrades (issue #15 partial) ([#28](https://github.com/joshrotenberg/claude-api/pull/28))
+
 ## [0.5.2](https://github.com/joshrotenberg/claude-api/compare/v0.5.1...v0.5.2) - 2026-05-01
 
 ### Fixed

--- a/crates/claude-api/Cargo.toml
+++ b/crates/claude-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-api"
-version = "0.5.2"
+version = "0.5.3"
 description = "Type-safe Rust client for the Anthropic API"
 keywords = ["anthropic", "claude", "api", "ai", "llm"]
 categories = ["api-bindings", "asynchronous"]


### PR DESCRIPTION



## 🤖 New release

* `claude-api`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `claude-api-test`: 0.5.2 -> 0.5.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-api`

<blockquote>

## [0.5.3](https://github.com/joshrotenberg/claude-api/compare/v0.5.2...v0.5.3) - 2026-05-02

### Added

- *(live-tests)* add test stubs for user-profiles, skills write, batches completion, conversation, runner ([#36](https://github.com/joshrotenberg/claude-api/pull/36))
- *(vertex)* VertexSigner RequestSigner impl for GCP Vertex AI auth ([#37](https://github.com/joshrotenberg/claude-api/pull/37))
- *(messages)* type-promote stop_details and context_management ([#35](https://github.com/joshrotenberg/claude-api/pull/35))
- *(models)* type-promote ModelInfo.capabilities ([#27](https://github.com/joshrotenberg/claude-api/pull/27))
- *(managed-agents)* wire research-preview header for outcomes ([#24](https://github.com/joshrotenberg/claude-api/pull/24))

### Other

- new examples + module header upgrades (issue #15 partial) ([#28](https://github.com/joshrotenberg/claude-api/pull/28))
</blockquote>

## `claude-api-test`

<blockquote>

## [0.5.3](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.2...claude-api-test-v0.5.3) - 2026-05-02

### Added

- *(live-tests)* add test stubs for user-profiles, skills write, batches completion, conversation, runner ([#36](https://github.com/joshrotenberg/claude-api/pull/36))
- *(test)* SSE cassette recording and replay support ([#38](https://github.com/joshrotenberg/claude-api/pull/38))
- *(models)* type-promote ModelInfo.capabilities ([#27](https://github.com/joshrotenberg/claude-api/pull/27))

### Other

- *(streaming)* record live cassette for messages.create_stream ([#39](https://github.com/joshrotenberg/claude-api/pull/39))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).