### PR TITLE
docs: new examples + module header upgrades (issue #15 partial)

### DIFF
--- a/crates/claude-api/examples/batches.rs
+++ b/crates/claude-api/examples/batches.rs
@@ -1,0 +1,89 @@
+//! Message Batches API: submit multiple requests, wait for completion, and
+//! read results.
+//!
+//! ```sh
+//! ANTHROPIC_API_KEY=sk-ant-... cargo run --example batches
+//! ```
+
+use claude_api::Client;
+use claude_api::batches::{BatchRequest, WaitOptions};
+use claude_api::messages::{ContentBlock, CreateMessageRequest, KnownBlock};
+use claude_api::types::ModelId;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = std::env::var("ANTHROPIC_API_KEY")
+        .map_err(|_| "ANTHROPIC_API_KEY must be set in the environment")?;
+    let client = Client::new(api_key);
+
+    // Build three independent requests. Each gets a stable custom_id so
+    // results can be correlated back to the inputs after the batch ends.
+    let requests = vec![
+        BatchRequest::new(
+            "capital-france",
+            CreateMessageRequest::builder()
+                .model(ModelId::HAIKU_4_5)
+                .max_tokens(64)
+                .user("What is the capital of France? One word.")
+                .build()?,
+        ),
+        BatchRequest::new(
+            "capital-japan",
+            CreateMessageRequest::builder()
+                .model(ModelId::HAIKU_4_5)
+                .max_tokens(64)
+                .user("What is the capital of Japan? One word.")
+                .build()?,
+        ),
+        BatchRequest::new(
+            "capital-brazil",
+            CreateMessageRequest::builder()
+                .model(ModelId::HAIKU_4_5)
+                .max_tokens(64)
+                .user("What is the capital of Brazil? One word.")
+                .build()?,
+        ),
+    ];
+
+    // Submit -- returns immediately with processing_status: in_progress.
+    let batch = client.batches().create(requests).await?;
+    println!(
+        "Submitted batch {}  (status: {:?})",
+        batch.id, batch.processing_status
+    );
+
+    // Poll until the batch ends or a 5-minute timeout fires.
+    let options = WaitOptions::default().timeout(std::time::Duration::from_secs(300));
+    let finished = client.batches().wait_for(&batch.id, options).await?;
+    println!("Batch ended  (status: {:?})", finished.processing_status);
+
+    // Fetch all results and print.
+    let items = client.batches().results(&batch.id).await?;
+    for item in &items {
+        match &item.result {
+            claude_api::batches::BatchResultPayload::Succeeded { message } => {
+                let text = message
+                    .content
+                    .iter()
+                    .find_map(|b| {
+                        if let ContentBlock::Known(KnownBlock::Text { text, .. }) = b {
+                            Some(text.as_str())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or("(no text)");
+                println!("  [{}] => {}", item.custom_id, text.trim());
+            }
+            claude_api::batches::BatchResultPayload::Errored { error } => {
+                println!("  [{}] => ERROR: {:?}", item.custom_id, error);
+            }
+            _ => {
+                println!("  [{}] => canceled or expired", item.custom_id);
+            }
+        }
+    }
+
+    println!("\n[{} results]", items.len());
+    Ok(())
+}

--- a/crates/claude-api/examples/bedrock.rs
+++ b/crates/claude-api/examples/bedrock.rs
@@ -1,0 +1,60 @@
+//! AWS Bedrock auth: sign requests with sigv4 instead of an API key.
+//!
+//! The example reads AWS credentials from the standard environment
+//! variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
+//! `AWS_SESSION_TOKEN`, `AWS_REGION`) and sends one message through the
+//! Bedrock Anthropic endpoint.
+//!
+//! ```sh
+//! AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_REGION=us-east-1 \
+//!     cargo run --example bedrock \
+//!     --features bedrock --no-default-features --features async,rustls,streaming,bedrock
+//! ```
+//!
+//! Note: Bedrock Anthropic model IDs use the `anthropic.` prefix, e.g.
+//! `anthropic.claude-sonnet-4-6-20251001-v1:0`.
+
+use std::sync::Arc;
+
+use claude_api::Client;
+use claude_api::bedrock::{BedrockCredentials, BedrockSigner};
+use claude_api::messages::{ContentBlock, CreateMessageRequest, KnownBlock};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let region = std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".into());
+
+    let creds = BedrockCredentials::from_env()
+        .ok_or("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set")?;
+    let signer = BedrockSigner::new(creds, &region);
+
+    // The Bedrock base URL routes to the regional endpoint.
+    let base_url = format!("https://bedrock-runtime.{region}.amazonaws.com");
+
+    let client = Client::builder()
+        .signer(Arc::new(signer))
+        .base_url(base_url)
+        .build()?;
+
+    // Bedrock model IDs use the full Amazon resource name format.
+    let model = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+
+    let request = CreateMessageRequest::builder()
+        .model(model)
+        .max_tokens(256)
+        .user("What is 2 + 2?")
+        .build()?;
+
+    let response = client.messages().create(request).await?;
+
+    for block in &response.content {
+        if let ContentBlock::Known(KnownBlock::Text { text, .. }) = block {
+            println!("{text}");
+        }
+    }
+    println!(
+        "\n[input: {} tokens, output: {} tokens]",
+        response.usage.input_tokens, response.usage.output_tokens,
+    );
+    Ok(())
+}

--- a/crates/claude-api/examples/managed_agents.rs
+++ b/crates/claude-api/examples/managed_agents.rs
@@ -1,0 +1,62 @@
+//! Managed Agents preview: create a session, send a message, and read
+//! the events back.
+//!
+//! Requires a provisioned agent and environment ID. The preview feature
+//! must be enabled; see <https://docs.anthropic.com/managed-agents>.
+//!
+//! ```sh
+//! ANTHROPIC_API_KEY=sk-ant-... \
+//! CLAUDE_AGENT_ID=agt_... \
+//!     cargo run --example managed_agents \
+//!     --features managed-agents-preview
+//! ```
+
+use claude_api::Client;
+use claude_api::managed_agents::events::OutgoingUserEvent;
+use claude_api::managed_agents::sessions::{AgentRef, CreateSessionRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key =
+        std::env::var("ANTHROPIC_API_KEY").map_err(|_| "ANTHROPIC_API_KEY must be set")?;
+    let agent_id = std::env::var("CLAUDE_AGENT_ID")
+        .map_err(|_| "CLAUDE_AGENT_ID must be set (e.g. agt_...)")?;
+
+    let client = Client::new(api_key);
+    let ma = client.managed_agents();
+
+    // Create a session against the latest version of the agent.
+    let session = ma
+        .sessions()
+        .create(
+            CreateSessionRequest::builder()
+                .agent(AgentRef::latest(&agent_id))
+                .build()?,
+        )
+        .await?;
+    println!(
+        "Session {} created (status: {:?})",
+        session.id, session.status
+    );
+
+    // Send the initial user message.
+    let sessions = ma.sessions();
+    let events_handle = sessions.events(session.id.clone());
+    events_handle
+        .send(&[OutgoingUserEvent::message(
+            "Hello! Summarize what you can do in two sentences.",
+        )])
+        .await?;
+    println!("User message sent.");
+
+    // List events produced so far (poll; for real workloads use .stream()).
+    let page = events_handle.list().await?;
+    println!("\nEvents received: {}", page.data.len());
+    for ev in &page.data {
+        if let Some(tag) = ev.type_tag() {
+            println!("  {tag}");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/claude-api/src/batches/mod.rs
+++ b/crates/claude-api/src/batches/mod.rs
@@ -16,6 +16,31 @@
 //! The batch ID is the only state you need to durably persist; reattach
 //! later by calling [`Batches::get(id)`](Batches::get) or
 //! [`Batches::wait_for(id, _)`](Batches::wait_for).
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use claude_api::{Client, batches::{BatchRequest, BatchResultPayload, WaitOptions},
+//!     messages::CreateMessageRequest, types::ModelId};
+//! # async fn run() -> Result<(), claude_api::Error> {
+//! let client = Client::new(std::env::var("ANTHROPIC_API_KEY").unwrap());
+//! let requests = vec![
+//!     BatchRequest::new("q1",
+//!         CreateMessageRequest::builder()
+//!             .model(ModelId::HAIKU_4_5).max_tokens(32).user("2 + 2?").build()?),
+//! ];
+//! let batch = client.batches().create(requests).await?;
+//! let finished = client.batches()
+//!     .wait_for(&batch.id, WaitOptions::default()).await?;
+//! let items = client.batches().results(&finished.id).await?;
+//! for item in &items {
+//!     if let BatchResultPayload::Succeeded { message } = &item.result {
+//!         println!("{}: {} tokens", item.custom_id, message.usage.output_tokens);
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
 
 pub mod types;
 

--- a/crates/claude-api/src/bedrock.rs
+++ b/crates/claude-api/src/bedrock.rs
@@ -10,11 +10,28 @@
 //! 3. Inject `anthropic_version: "bedrock-2023-05-31"` and remove the
 //!    `model` field from the body (Bedrock takes the model in the URL).
 //!
-//! Mixing those concerns into the typed namespace handles is a v0.5+
-//! design discussion; for now this module's job is just to make the
-//! request *signable*.
+//! The typed namespace handles still use Anthropic's URL shape; Bedrock
+//! model IDs and the `anthropic_version` header must be supplied by the
+//! caller. See `examples/bedrock.rs` for a complete working sketch.
 //!
 //! Gated on the `bedrock` feature.
+//!
+//! # Set up the client
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use claude_api::{Client, bedrock::{BedrockCredentials, BedrockSigner}};
+//! # fn run() -> Result<(), claude_api::Error> {
+//! let region = std::env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".into());
+//! let creds = BedrockCredentials::from_env()
+//!     .expect("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set");
+//! let client = Client::builder()
+//!     .signer(Arc::new(BedrockSigner::new(creds, &region)))
+//!     .base_url(format!("https://bedrock-runtime.{region}.amazonaws.com"))
+//!     .build()?;
+//! # Ok(())
+//! # }
+//! ```
 
 #![cfg(feature = "bedrock")]
 #![cfg_attr(docsrs, doc(cfg(feature = "bedrock")))]

--- a/crates/claude-api/src/files/api.rs
+++ b/crates/claude-api/src/files/api.rs
@@ -1,4 +1,15 @@
 //! The async `Files<'a>` namespace.
+//!
+//! | Method | Path | Function |
+//! |---|---|---|
+//! | `POST` | `/v1/files` | `Files::upload` / `Files::upload_path` |
+//! | `GET` | `/v1/files/{id}` | `Files::get` |
+//! | `GET` | `/v1/files/{id}/content` | `Files::download` / `Files::download_to` |
+//! | `GET` | `/v1/files` | `Files::list` / `Files::list_all` |
+//! | `DELETE` | `/v1/files/{id}` | `Files::delete` |
+//!
+//! Obtain via [`Client::files`](crate::Client::files). Both upload and
+//! download support true streaming I/O via the `_path` / `_to` variants.
 
 #![cfg(feature = "async")]
 

--- a/crates/claude-api/src/managed_agents/mod.rs
+++ b/crates/claude-api/src/managed_agents/mod.rs
@@ -29,6 +29,28 @@
 //! - [`memory_stores`] -- persistent memory across sessions.
 //! - [`agents`] -- agent definitions (create only in this version; full
 //!   CRUD lands once docs are available).
+//!
+//! # Create a session and send a message
+//!
+//! ```no_run
+//! use claude_api::{Client,
+//!     managed_agents::sessions::{AgentRef, CreateSessionRequest},
+//!     managed_agents::events::OutgoingUserEvent};
+//! # async fn run() -> Result<(), claude_api::Error> {
+//! let client = Client::new(std::env::var("ANTHROPIC_API_KEY").unwrap());
+//! let ma = client.managed_agents();
+//! let session = ma.sessions().create(
+//!     CreateSessionRequest::builder()
+//!         .agent(AgentRef::latest("agt_..."))
+//!         .build()?,
+//! ).await?;
+//! let sessions = ma.sessions();
+//! sessions.events(session.id)
+//!     .send(&[OutgoingUserEvent::message("Hello!")])
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
 
 #![cfg(feature = "managed-agents-preview")]
 #![cfg_attr(docsrs, doc(cfg(feature = "managed-agents-preview")))]

--- a/crates/claude-api/src/messages/api.rs
+++ b/crates/claude-api/src/messages/api.rs
@@ -1,9 +1,34 @@
-//! The Messages namespace: [`Messages::create`], [`Messages::count_tokens`],
-//! and their `_with_beta` siblings.
+//! The Messages API namespace.
+//!
+//! # Endpoints
+//!
+//! | Method | Path | Function |
+//! |---|---|---|
+//! | `POST` | `/v1/messages` | [`Messages::create`] / [`Messages::create_stream`] |
+//! | `POST` | `/v1/messages/count_tokens` | [`Messages::count_tokens`] |
 //!
 //! Obtain via [`Client::messages`](crate::Client::messages).
 //!
-//! Streaming (`create_stream`) lands in task #12.
+//! # Quick start
+//!
+//! ```no_run
+//! use claude_api::{Client, messages::CreateMessageRequest, types::ModelId};
+//! # async fn run() -> Result<(), claude_api::Error> {
+//! let client = Client::new(std::env::var("ANTHROPIC_API_KEY").unwrap());
+//! let resp = client
+//!     .messages()
+//!     .create(
+//!         CreateMessageRequest::builder()
+//!             .model(ModelId::SONNET_4_6)
+//!             .max_tokens(256)
+//!             .user("Hello!")
+//!             .build()?,
+//!     )
+//!     .await?;
+//! println!("{} output tokens", resp.usage.output_tokens);
+//! # Ok(())
+//! # }
+//! ```
 
 #![cfg(feature = "async")]
 

--- a/crates/claude-api/src/messages/input.rs
+++ b/crates/claude-api/src/messages/input.rs
@@ -1,5 +1,13 @@
 //! Request-side message structures: [`MessageInput`], [`MessageContent`],
 //! [`SystemPrompt`].
+//!
+//! [`MessageInput`] is one turn in the conversation history sent to the API.
+//! Build via [`MessageInput::user`] / [`MessageInput::assistant`] for the
+//! common cases, or construct [`MessageContent::Blocks`] directly when you
+//! need multiple content blocks in one turn.
+//!
+//! [`SystemPrompt`] wraps the system string with optional per-block cache
+//! breakpoints for prompt caching.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/claude-api/src/messages/mcp.rs
+++ b/crates/claude-api/src/messages/mcp.rs
@@ -1,4 +1,9 @@
 //! MCP server configuration for the `mcp_servers` request field.
+//!
+//! Pass one or more [`McpServerConfig`] values when constructing a
+//! [`CreateMessageRequest`](crate::messages::request::CreateMessageRequest)
+//! to give the model access to Model Context Protocol tools hosted at
+//! external URLs. The server must speak the MCP protocol over HTTP/SSE.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/claude-api/src/messages/request.rs
+++ b/crates/claude-api/src/messages/request.rs
@@ -1,8 +1,14 @@
 //! Request payloads for the Messages API.
 //!
 //! [`CreateMessageRequest`] is the typed builder for `POST /v1/messages`.
-//! [`CountTokensRequest`] is its slimmer sibling for
-//! `POST /v1/messages/count_tokens`.
+//! Every field is optional except `model` and `max_tokens`; the fluent
+//! builder exposes convenience methods (`.user()`, `.system()`,
+//! `.tools()`, `.cache_control_on_system()`, etc.) alongside the raw
+//! field setters.
+//!
+//! [`CountTokensRequest`] is the slimmer sibling used by
+//! `POST /v1/messages/count_tokens`; it accepts the same message list and
+//! tools but omits generation parameters.
 
 use serde::Serialize;
 

--- a/crates/claude-api/src/messages/response.rs
+++ b/crates/claude-api/src/messages/response.rs
@@ -1,4 +1,13 @@
-//! Response types: [`Message`], [`CountTokensResponse`], [`ContainerInfo`].
+//! Response types returned by the Messages API.
+//!
+//! | Type | Source |
+//! |---|---|
+//! | [`Message`] | `POST /v1/messages` (non-streaming) or [`EventStream::aggregate`](crate::messages::stream::EventStream::aggregate) |
+//! | [`CountTokensResponse`] | `POST /v1/messages/count_tokens` |
+//! | [`ContainerInfo`] | Nested in `Message::container` when code-execution containers are active |
+//!
+//! `Message.content` is `Vec<ContentBlock>` -- iterate it with a match on
+//! [`crate::messages::ContentBlock::Known`] to extract text, tool calls, etc.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/claude-api/src/messages/stream.rs
+++ b/crates/claude-api/src/messages/stream.rs
@@ -5,9 +5,44 @@
 //! byte-for-byte. Strict-on-known semantics: a known tag with a malformed
 //! body returns a deserialization error rather than silently falling through.
 //!
-//! [`EventStream`] is the typed wrapper around the SSE wire format; call
-//! [`EventStream::aggregate`] to reconstruct a [`Message`] from a full
-//! `message_start → ... → message_stop` sequence.
+//! [`EventStream`] is the typed wrapper around the SSE wire format. Two
+//! consumption patterns:
+//!
+//! - **Event-by-event** via [`futures_util::StreamExt::next`] -- print text
+//!   deltas as they arrive (see `examples/streaming.rs`).
+//! - **Aggregate** via [`EventStream::aggregate`] -- wait for the full
+//!   `message_start ... message_stop` sequence and get back a [`Message`],
+//!   identical to what [`Messages::create`](crate::messages::Messages::create)
+//!   returns.
+//!
+//! # Print text deltas as they arrive
+//!
+//! ```no_run
+//! use claude_api::{Client, messages::{CreateMessageRequest, KnownContentDelta,
+//!     KnownStreamEvent, ContentDelta, StreamEvent}, types::ModelId};
+//! use futures_util::StreamExt;
+//! # async fn run() -> Result<(), claude_api::Error> {
+//! let client = Client::new(std::env::var("ANTHROPIC_API_KEY").unwrap());
+//! let request = CreateMessageRequest::builder()
+//!     .model(ModelId::SONNET_4_6)
+//!     .max_tokens(256)
+//!     .user("Tell me a fact.")
+//!     .build()?;
+//! let mut stream = client.messages().create_stream(request).await?;
+//! while let Some(event) = stream.next().await {
+//!     if let StreamEvent::Known(KnownStreamEvent::ContentBlockDelta {
+//!         delta: ContentDelta::Known(KnownContentDelta::TextDelta { text }),
+//!         ..
+//!     }) = event?
+//!     {
+//!         print!("{text}");
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Gated on the `streaming` feature.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/claude-api/src/messages/thinking.rs
+++ b/crates/claude-api/src/messages/thinking.rs
@@ -1,4 +1,11 @@
 //! Configuration for extended thinking.
+//!
+//! Pass a [`ThinkingConfig::Enabled`] value in the request to have the model
+//! emit `thinking` blocks before its final answer. `budget_tokens` caps how
+//! much of `max_tokens` the model may spend on reasoning.
+//!
+//! Extended thinking is supported by Claude Sonnet 4.6+ and Claude Opus 4.x.
+//! See [`crate::models::ModelCapabilities`] to check model support at runtime.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/claude-api/src/messages/tools.rs
+++ b/crates/claude-api/src/messages/tools.rs
@@ -4,6 +4,44 @@
 //! a user-defined function ([`CustomTool`]) or a server-side built-in
 //! ([`BuiltinTool`]) like web search or code execution. [`ToolChoice`]
 //! controls whether and which tool the model must invoke.
+//!
+//! For high-level dispatch (registry, parallel calls, agent loop) see
+//! [`crate::tool_dispatch`]. For `#[derive(Tool)]` see `claude-api-derive`.
+//!
+//! # Define and send a custom tool
+//!
+//! ```no_run
+//! use claude_api::{Client, messages::{CreateMessageRequest, Tool, CustomTool},
+//!     types::ModelId};
+//! use serde_json::json;
+//! # async fn run() -> Result<(), claude_api::Error> {
+//! let weather = Tool::Custom(
+//!     CustomTool::new(
+//!         "get_weather",
+//!         json!({
+//!             "type": "object",
+//!             "properties": {"city": {"type": "string"}},
+//!             "required": ["city"]
+//!         }),
+//!     )
+//!     .description("Return the current weather for a city."),
+//! );
+//! let client = Client::new(std::env::var("ANTHROPIC_API_KEY").unwrap());
+//! let resp = client
+//!     .messages()
+//!     .create(
+//!         CreateMessageRequest::builder()
+//!             .model(ModelId::SONNET_4_6)
+//!             .max_tokens(512)
+//!             .tools(vec![weather])
+//!             .user("What's the weather in Tokyo?")
+//!             .build()?,
+//!     )
+//!     .await?;
+//! println!("{:?}", resp.stop_reason);
+//! # Ok(())
+//! # }
+//! ```
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/claude-api/src/tool_dispatch/mod.rs
+++ b/crates/claude-api/src/tool_dispatch/mod.rs
@@ -1,16 +1,23 @@
-//! Tool-dispatch foundation: the [`Tool`] trait, plus a registry and agent
-//! loop runner (the latter two land in v0.2 tasks #19 and #20).
+//! Tool-dispatch: the [`Tool`] trait, registry, typed inputs, and the agent
+//! loop runner.
 //!
-//! v0.2 will layer three ergonomic shapes on this single trait:
+//! Three ergonomic shapes for registering tools:
 //!
-//! 1. [`Tool`] -- async trait. Implement directly when each tool is its
-//!    own type (typical for shared crate code).
-//! 2. `ToolRegistry::register` -- closure-based handler. The registry wraps
-//!    closures in an internal `FnTool<F>` adapter that implements [`Tool`].
-//! 3. `ToolRegistry::register_typed::<Args>` -- typed-input handler driven
-//!    by `schemars`. Internally builds a `Tool` impl that deserializes the
-//!    raw input into `Args` before dispatching. Behind the
-//!    `schemars-tools` feature.
+//! 1. **[`Tool`] trait** -- implement directly when each tool is its own type.
+//!    Gives full control over the JSON Schema, the async handler, and errors.
+//! 2. **[`ToolRegistry::register`]** -- closure-based handler. The registry
+//!    wraps closures in an internal `FnTool<F>` adapter. Convenient for
+//!    one-off tools that don't need a dedicated type.
+//! 3. **[`TypedTool`] + `ToolRegistry::register_typed`** -- typed-input
+//!    handler driven by `schemars`. The input JSON is deserialized into a
+//!    concrete `Args` type before dispatch. Behind the `schemars-tools`
+//!    feature (or use `#[derive(Tool)]` from `claude-api-derive` for the
+//!    most ergonomic form).
+//!
+//! The agent loop lives in [`runner`] (feature `conversation`). It drives
+//! repeated `messages.create` calls, dispatching tools in parallel via
+//! [`Tool::invoke`], optionally enforcing a cost budget and a mid-stream
+//! approval gate.
 //!
 //! Gated on the `async` feature.
 

--- a/crates/claude-api/src/tool_dispatch/registry.rs
+++ b/crates/claude-api/src/tool_dispatch/registry.rs
@@ -5,12 +5,16 @@
 //!
 //! - [`ToolRegistry::register_tool`] takes anything that implements [`Tool`]
 //!   directly.
-//! - [`ToolRegistry::register`] takes a closure plus name/schema; the
-//!   closure is wrapped in an internal [`FnTool`] that implements [`Tool`].
+//! - [`ToolRegistry::register`] / [`ToolRegistry::register_described`] take
+//!   a closure plus name/schema; the closure is wrapped in an internal
+//!   [`FnTool`] adapter.
 //!
-//! Both reduce to the same `Arc<dyn Tool>`, so the agent loop runner
-//! (#20) and the model's tool list ([`ToolRegistry::to_messages_tools`])
-//! treat them identically.
+//! Both reduce to the same `Arc<dyn Tool>`. [`ToolRegistry::to_messages_tools`]
+//! converts the registered schemas into the [`Tool`](crate::messages::Tool)
+//! slice needed by `CreateMessageRequest::tools`.
+//!
+//! For typed inputs derived from a Rust struct see
+//! [`crate::tool_dispatch::TypedTool`] and the `schemars-tools` feature.
 
 use std::collections::HashMap;
 use std::future::Future;

--- a/crates/claude-api/src/tool_dispatch/runner.rs
+++ b/crates/claude-api/src/tool_dispatch/runner.rs
@@ -6,6 +6,36 @@
 //!
 //! Gated on the `conversation` feature in addition to the parent
 //! `tool_dispatch` module's `async` gate.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use claude_api::{Client, conversation::Conversation,
+//!     tool_dispatch::{RunOptions, ToolError, ToolRegistry}, types::ModelId};
+//! use serde_json::json;
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let client = Client::new(std::env::var("ANTHROPIC_API_KEY").unwrap());
+//! let mut registry = ToolRegistry::new();
+//! registry.register_described(
+//!     "get_weather",
+//!     "Return the current weather for a city.",
+//!     json!({
+//!         "type": "object",
+//!         "properties": {"city": {"type": "string"}},
+//!         "required": ["city"]
+//!     }),
+//!     |input| async move {
+//!         let city = input["city"].as_str().ok_or_else(|| ToolError::invalid_input("missing city"))?;
+//!         Ok(json!({"city": city, "temp_f": 72}))
+//!     },
+//! );
+//! let mut convo = Conversation::new(ModelId::SONNET_4_6, 1024);
+//! convo.push_user("What's the weather in Paris?");
+//! let result = client.run(&mut convo, &registry, RunOptions::default()).await?;
+//! println!("{:?}", result.stop_reason);
+//! # Ok(())
+//! # }
+//! ```
 
 #![cfg(feature = "conversation")]
 

--- a/crates/claude-api/src/tool_dispatch/tool.rs
+++ b/crates/claude-api/src/tool_dispatch/tool.rs
@@ -1,8 +1,15 @@
 //! The [`Tool`] async trait and its companion [`ToolError`].
 //!
-//! [`Tool`] is the foundation for every tool-dispatch shape v0.2 ships:
-//! direct trait implementations, closure adapters via `FnTool` (#19), and
-//! schemars-driven typed handlers (#21) all reduce to a `Tool` impl.
+//! [`Tool`] is the foundation for every tool-dispatch shape: direct
+//! trait implementations, closure adapters via
+//! [`FnTool`](crate::tool_dispatch::FnTool), and schemars-driven typed
+//! handlers ([`crate::tool_dispatch::TypedTool`]) all reduce to a
+//! `dyn Tool` stored in the registry.
+//!
+//! [`ToolApprover`] is the mid-stream approval gate: each pending
+//! tool call is passed to an approver before it executes; return
+//! [`ApprovalDecision::Deny`] to short-circuit the tool and inject an
+//! error result instead.
 
 use async_trait::async_trait;
 

--- a/crates/claude-api/src/types.rs
+++ b/crates/claude-api/src/types.rs
@@ -1,4 +1,12 @@
-//! Foundational shared types: [`ModelId`], [`Role`], [`Usage`], [`StopReason`].
+//! Foundational shared types used across every API resource.
+//!
+//! | Type | Purpose |
+//! |---|---|
+//! | [`ModelId`] | String-newtype for model identifiers; common models as associated constants |
+//! | [`Role`] | `user` / `assistant` message role |
+//! | [`Usage`] | Token counts returned with every `Message` response |
+//! | [`StopReason`] | Why the model stopped generating (`end_turn`, `max_tokens`, `tool_use`, ...) |
+//! | [`ServiceTier`] | `standard` / `priority` / `batch` service tier on the response |
 
 use std::borrow::Cow;
 use std::fmt;


### PR DESCRIPTION
Closes #15.

## Summary

### New runnable examples (3)

| File | What it demonstrates |
|---|---|
| `examples/batches.rs` | Submit a 3-entry batch, `wait_for` completion, read results |
| `examples/bedrock.rs` | `BedrockSigner` sigv4 auth with env-var credentials |
| `examples/managed_agents.rs` | Create session, send message, list events (feature `managed-agents-preview`) |

### Module headers upgraded (13 files)

Every module now has a header that states its purpose, lists endpoints
or types, and cross-links to related modules:

- `messages/api.rs` -- stale task reference removed; endpoint table + snippet added
- `messages/stream.rs` -- streaming event-by-event `no_run` example added
- `messages/tools.rs` -- custom tool definition + create example added
- `messages/input.rs` -- `MessageContent`/`SystemPrompt` context added
- `messages/request.rs` -- builder field overview added
- `messages/response.rs` -- source table + `ContentBlock` note added
- `files/api.rs` -- endpoint table added
- `tool_dispatch/mod.rs` -- stale v0.2 planning text replaced with accurate description
- `tool_dispatch/tool.rs` -- stale v0.2 references removed; `ToolApprover` described
- `tool_dispatch/registry.rs` -- registration shapes and `to_messages_tools` clarified
- `tool_dispatch/runner.rs` -- agent loop `no_run` example added
- `batches/mod.rs` -- quick-start `no_run` snippet added
- `bedrock.rs` -- client setup `no_run` snippet added
- `managed_agents/mod.rs` -- session lifecycle `no_run` snippet added

Plus the first commit in this PR (already reviewed):
- `types.rs`, `messages/thinking.rs`, `messages/mcp.rs` header upgrades
- `tool_dispatch/mod.rs` stale text removed

### Examples-to-doc sync

Every file under `examples/` now has a matching inline `no_run` snippet
in the relevant module's doc-string.

## Verification

- `cargo doc --workspace --all-features` clean (no broken intra-doc links)
- `cargo test --workspace --all-features`: 515 lib + 24 doctests pass
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` clean
- All three new examples compile under their feature gates