### PR TITLE
feat(messages): type-promote stop_details and context_management

### DIFF
--- a/crates/claude-api/src/messages/mod.rs
+++ b/crates/claude-api/src/messages/mod.rs
@@ -80,7 +80,11 @@ pub use request::{
     CountTokensRequest, CountTokensRequestBuilder, CreateMessageRequest,
     CreateMessageRequestBuilder,
 };
-pub use response::{ContainerInfo, CountTokensResponse, Message};
+pub use response::{
+    ClearThinkingEdit, ClearToolUsesEdit, ContainerInfo, ContextEdit, CountTokensResponse,
+    KnownContextEdit, KnownStopDetails, Message, RefusalStopDetails, ResponseContextManagement,
+    StopDetails,
+};
 pub use stream::{ContentDelta, KnownContentDelta, KnownStreamEvent, MessageDelta, StreamEvent};
 pub use thinking::ThinkingConfig;
 pub use tools::{BuiltinTool, CustomTool, KnownBuiltinTool, Tool, ToolChoice, UserLocation};

--- a/crates/claude-api/src/messages/response.rs
+++ b/crates/claude-api/src/messages/response.rs
@@ -11,6 +11,7 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::forward_compat::dispatch_known_or_other;
 use crate::messages::content::ContentBlock;
 use crate::types::{ModelId, Role, StopReason, Usage};
 
@@ -45,27 +46,188 @@ pub struct Message {
     /// Structured information about *why* the model stopped (e.g. for
     /// `refusal` stops, the policy category and an explanation). `None`
     /// when no extra detail is reported.
-    ///
-    /// TODO: type as a closed enum once more `stop_details` shapes are
-    /// public. Currently preserved as raw JSON for forward-compat.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub stop_details: Option<serde_json::Value>,
+    pub stop_details: Option<StopDetails>,
     /// Token usage and related counters.
     #[serde(default)]
     pub usage: Usage,
-    /// Information about context-management edits applied to the
-    /// request (e.g. trimmed history). Present only when
-    /// `context-management-2025-06-27` is in play.
-    ///
-    /// TODO: type as `BetaResponseContextManagement` once the shape
-    /// stabilizes. Currently preserved as raw JSON.
+    /// Context-management edits applied to the request (e.g. trimmed
+    /// thinking blocks or tool-use history). Present only when a
+    /// context-management strategy was active and triggered.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub context_management: Option<serde_json::Value>,
+    pub context_management: Option<ResponseContextManagement>,
     /// Container metadata, present when the request used the code-execution
     /// container tool.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container: Option<ContainerInfo>,
 }
+
+// ---------------------------------------------------------------------------
+// stop_details
+// ---------------------------------------------------------------------------
+
+/// Structured information about why the model stopped.
+///
+/// Forward-compatible: unknown `type` tags deserialize into
+/// [`StopDetails::Other`] with the raw JSON preserved byte-for-byte.
+/// Currently only one variant (`Refusal`) is known; new variants may appear
+/// in future API versions.
+#[derive(Debug, Clone, PartialEq)]
+pub enum StopDetails {
+    /// A stop-details payload whose `type` is recognized.
+    Known(KnownStopDetails),
+    /// A stop-details payload whose `type` is not recognized; raw JSON
+    /// preserved.
+    Other(serde_json::Value),
+}
+
+/// All stop-details variants known to this SDK version.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum KnownStopDetails {
+    /// The model stopped because it refused the request on policy grounds.
+    Refusal(RefusalStopDetails),
+}
+
+/// Policy-refusal stop details.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct RefusalStopDetails {
+    /// The policy category that triggered the refusal (`"cyber"`, `"bio"`,
+    /// or `None` when the refusal doesn't map to a named category).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub category: Option<String>,
+    /// Human-readable explanation of the refusal. Not guaranteed to be
+    /// stable; `None` when no explanation is available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub explanation: Option<String>,
+}
+
+const KNOWN_STOP_DETAILS_TAGS: &[&str] = &["refusal"];
+
+impl Serialize for StopDetails {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            StopDetails::Known(k) => k.serialize(s),
+            StopDetails::Other(v) => v.serialize(s),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for StopDetails {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = serde_json::Value::deserialize(d)?;
+        dispatch_known_or_other(
+            raw,
+            KNOWN_STOP_DETAILS_TAGS,
+            StopDetails::Known,
+            StopDetails::Other,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+impl From<KnownStopDetails> for StopDetails {
+    fn from(k: KnownStopDetails) -> Self {
+        StopDetails::Known(k)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// context_management
+// ---------------------------------------------------------------------------
+
+/// Context-management edits applied during the request.
+///
+/// Present when a context-management strategy (e.g. `compact_20260112`,
+/// `clear_thinking_20251015`) was active and triggered. Each edit in
+/// `applied_edits` is forward-compatible: unknown `type` tags fall through
+/// to [`ContextEdit::Other`].
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ResponseContextManagement {
+    /// The edits applied, in order.
+    #[serde(default)]
+    pub applied_edits: Vec<ContextEdit>,
+}
+
+/// One context-management edit.
+///
+/// Forward-compatible: unknown `type` tags deserialize into
+/// [`ContextEdit::Other`] with the raw JSON preserved byte-for-byte.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ContextEdit {
+    /// An edit whose `type` is recognized.
+    Known(KnownContextEdit),
+    /// An edit whose `type` is not recognized; raw JSON preserved.
+    Other(serde_json::Value),
+}
+
+/// All context-edit variants known to this SDK version.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum KnownContextEdit {
+    /// Cleared one or more thinking blocks from the history.
+    #[serde(rename = "clear_thinking_20251015")]
+    ClearThinking(ClearThinkingEdit),
+    /// Cleared one or more tool-use / tool-result pairs from the history.
+    #[serde(rename = "clear_tool_uses_20250919")]
+    ClearToolUses(ClearToolUsesEdit),
+}
+
+/// Details for a `clear_thinking_20251015` context-management edit.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ClearThinkingEdit {
+    /// Number of input tokens cleared by this edit.
+    pub cleared_input_tokens: u64,
+    /// Number of thinking turns that were cleared.
+    pub cleared_thinking_turns: u64,
+}
+
+/// Details for a `clear_tool_uses_20250919` context-management edit.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct ClearToolUsesEdit {
+    /// Number of input tokens cleared by this edit.
+    pub cleared_input_tokens: u64,
+    /// Number of tool-use/tool-result pairs that were cleared.
+    pub cleared_tool_uses: u64,
+}
+
+const KNOWN_CONTEXT_EDIT_TAGS: &[&str] = &["clear_thinking_20251015", "clear_tool_uses_20250919"];
+
+impl Serialize for ContextEdit {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        match self {
+            ContextEdit::Known(k) => k.serialize(s),
+            ContextEdit::Other(v) => v.serialize(s),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ContextEdit {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let raw = serde_json::Value::deserialize(d)?;
+        dispatch_known_or_other(
+            raw,
+            KNOWN_CONTEXT_EDIT_TAGS,
+            ContextEdit::Known,
+            ContextEdit::Other,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+impl From<KnownContextEdit> for ContextEdit {
+    fn from(k: KnownContextEdit) -> Self {
+        ContextEdit::Known(k)
+    }
+}
+
+// ---------------------------------------------------------------------------
 
 fn default_message_kind() -> String {
     "message".to_owned()
@@ -203,6 +365,126 @@ mod tests {
         let v = serde_json::to_value(&msg).expect("serialize");
         let parsed: Message = serde_json::from_value(v).expect("deserialize");
         assert_eq!(parsed, msg);
+    }
+
+    #[test]
+    fn stop_details_refusal_round_trips() {
+        let raw = json!({
+            "type": "refusal",
+            "category": "cyber",
+            "explanation": "Request involves offensive cyber techniques."
+        });
+        let sd: StopDetails = serde_json::from_value(raw.clone()).unwrap();
+        match &sd {
+            StopDetails::Known(KnownStopDetails::Refusal(r)) => {
+                assert_eq!(r.category.as_deref(), Some("cyber"));
+                assert!(r.explanation.is_some());
+            }
+            other => panic!("expected Refusal, got {other:?}"),
+        }
+        assert_eq!(serde_json::to_value(&sd).unwrap(), raw);
+    }
+
+    #[test]
+    fn stop_details_null_category_round_trips() {
+        let raw = json!({"type": "refusal", "category": null, "explanation": null});
+        let sd: StopDetails = serde_json::from_value(raw).unwrap();
+        if let StopDetails::Known(KnownStopDetails::Refusal(r)) = &sd {
+            assert!(r.category.is_none());
+        } else {
+            panic!("expected Refusal");
+        }
+    }
+
+    #[test]
+    fn stop_details_unknown_type_falls_through_to_other() {
+        let raw = json!({"type": "future_stop_reason", "detail": 42});
+        let sd: StopDetails = serde_json::from_value(raw.clone()).unwrap();
+        assert!(matches!(sd, StopDetails::Other(_)));
+        assert_eq!(serde_json::to_value(&sd).unwrap(), raw);
+    }
+
+    #[test]
+    fn context_edit_clear_thinking_round_trips() {
+        let raw = json!({
+            "type": "clear_thinking_20251015",
+            "cleared_input_tokens": 1500,
+            "cleared_thinking_turns": 3
+        });
+        let edit: ContextEdit = serde_json::from_value(raw.clone()).unwrap();
+        match &edit {
+            ContextEdit::Known(KnownContextEdit::ClearThinking(e)) => {
+                assert_eq!(e.cleared_input_tokens, 1500);
+                assert_eq!(e.cleared_thinking_turns, 3);
+            }
+            other => panic!("expected ClearThinking, got {other:?}"),
+        }
+        assert_eq!(serde_json::to_value(&edit).unwrap(), raw);
+    }
+
+    #[test]
+    fn context_edit_clear_tool_uses_round_trips() {
+        let raw = json!({
+            "type": "clear_tool_uses_20250919",
+            "cleared_input_tokens": 800,
+            "cleared_tool_uses": 2
+        });
+        let edit: ContextEdit = serde_json::from_value(raw.clone()).unwrap();
+        if let ContextEdit::Known(KnownContextEdit::ClearToolUses(e)) = &edit {
+            assert_eq!(e.cleared_tool_uses, 2);
+        } else {
+            panic!("expected ClearToolUses");
+        }
+        assert_eq!(serde_json::to_value(&edit).unwrap(), raw);
+    }
+
+    #[test]
+    fn context_edit_unknown_type_falls_through_to_other() {
+        let raw = json!({"type": "compact_20260112", "summary": "..."});
+        let edit: ContextEdit = serde_json::from_value(raw.clone()).unwrap();
+        assert!(matches!(edit, ContextEdit::Other(_)));
+        assert_eq!(serde_json::to_value(&edit).unwrap(), raw);
+    }
+
+    #[test]
+    fn response_context_management_round_trips() {
+        let raw = json!({
+            "applied_edits": [
+                {"type": "clear_thinking_20251015", "cleared_input_tokens": 500, "cleared_thinking_turns": 1},
+                {"type": "clear_tool_uses_20250919", "cleared_input_tokens": 200, "cleared_tool_uses": 1}
+            ]
+        });
+        let cm: ResponseContextManagement = serde_json::from_value(raw.clone()).unwrap();
+        assert_eq!(cm.applied_edits.len(), 2);
+        assert!(matches!(
+            &cm.applied_edits[0],
+            ContextEdit::Known(KnownContextEdit::ClearThinking(_))
+        ));
+        assert_eq!(serde_json::to_value(&cm).unwrap(), raw);
+    }
+
+    #[test]
+    fn message_with_stop_details_and_context_management_round_trips() {
+        let raw = json!({
+            "id": "msg_refusal",
+            "type": "message",
+            "role": "assistant",
+            "content": [],
+            "model": "claude-sonnet-4-6",
+            "stop_reason": "refusal",
+            "usage": {"input_tokens": 5, "output_tokens": 0},
+            "stop_details": {"type": "refusal", "category": "bio", "explanation": "Biosecurity policy."},
+            "context_management": {
+                "applied_edits": [
+                    {"type": "clear_thinking_20251015", "cleared_input_tokens": 300, "cleared_thinking_turns": 2}
+                ]
+            }
+        });
+        let msg: Message = serde_json::from_value(raw).unwrap();
+        assert!(msg.stop_details.is_some());
+        assert!(msg.context_management.is_some());
+        let cm = msg.context_management.as_ref().unwrap();
+        assert_eq!(cm.applied_edits.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #9, closes #10.

## Summary

Promotes two `Option<serde_json::Value>` fields on `Message` to typed, forward-compatible enums. Same `Known(...) | Other(Value)` pattern used by `ContentBlock`, `Citation`, and `StreamEvent`.

### `stop_details` (#9)

`Message.stop_details: Option<StopDetails>`

| Type | Purpose |
|---|---|
| `StopDetails` | Outer forward-compat enum |
| `KnownStopDetails::Refusal(RefusalStopDetails)` | Policy-refusal stop |
| `RefusalStopDetails` | `category` ("cyber" \| "bio" \| null) + `explanation` (nullable) |

### `context_management` (#10)

`Message.context_management: Option<ResponseContextManagement>`

| Type | Purpose |
|---|---|
| `ResponseContextManagement` | `{ applied_edits: Vec<ContextEdit> }` |
| `KnownContextEdit::ClearThinking(ClearThinkingEdit)` | `cleared_input_tokens`, `cleared_thinking_turns` |
| `KnownContextEdit::ClearToolUses(ClearToolUsesEdit)` | `cleared_input_tokens`, `cleared_tool_uses` |

Future edit types (e.g. a compact response edit) fall through to `ContextEdit::Other(Value)` and round-trip cleanly.

### New public exports (from `messages::`)

`StopDetails`, `KnownStopDetails`, `RefusalStopDetails`, `ResponseContextManagement`, `ContextEdit`, `KnownContextEdit`, `ClearThinkingEdit`, `ClearToolUsesEdit`

## Tests (8 new)

- `stop_details_refusal_round_trips`
- `stop_details_null_category_round_trips`
- `stop_details_unknown_type_falls_through_to_other`
- `context_edit_clear_thinking_round_trips`
- `context_edit_clear_tool_uses_round_trips`
- `context_edit_unknown_type_falls_through_to_other`
- `response_context_management_round_trips`
- `message_with_stop_details_and_context_management_round_trips`

523 lib tests pass. Clippy clean. `cargo doc` clean.