### PR TITLE
feat(test): SSE cassette recording and replay support

### DIFF
--- a/crates/claude-api-test/src/lib.rs
+++ b/crates/claude-api-test/src/lib.rs
@@ -232,13 +232,47 @@ impl Cassette {
 /// Mocks are mounted in cassette order. wiremock's first-match semantics
 /// mean that for two exchanges with the same `(method, path)`, the
 /// earlier one wins -- match by request body to disambiguate.
+///
+/// SSE responses (exchanges whose `headers` list contains
+/// `content-type: text/event-stream`) are served as raw text so the
+/// `eventsource-stream` parser on the client side sees the SSE wire
+/// format rather than a JSON-encoded body.
 pub async fn mount_cassette(server: &wiremock::MockServer, cassette: &Cassette) {
     use wiremock::matchers::{body_json, method, path};
     use wiremock::{Mock, ResponseTemplate};
 
     for ex in &cassette.exchanges {
-        let mut response = ResponseTemplate::new(ex.status).set_body_json(ex.response.clone());
+        // Detect SSE exchanges: header list contains content-type:
+        // text/event-stream.  In that case the `response` field holds the
+        // raw SSE wire text as a JSON string; serve it as raw bytes so
+        // the client's `eventsource-stream` parser receives the expected
+        // wire format.
+        let is_sse = ex.headers.iter().any(|(k, v)| {
+            k.eq_ignore_ascii_case("content-type") && v.contains("text/event-stream")
+        });
+
+        let mut response = if is_sse {
+            // `response` is a JSON String containing the SSE wire text.
+            // Use `set_body_raw` so wiremock serves the body with
+            // `content-type: text/event-stream` rather than the default
+            // `text/plain` that `set_body_string` produces. This ensures
+            // the `eventsource-stream` parser on the client side receives
+            // the wire format it expects.
+            let body = ex.response.as_str().unwrap_or("").as_bytes().to_owned();
+            ResponseTemplate::new(ex.status).set_body_raw(body, "text/event-stream")
+        } else {
+            ResponseTemplate::new(ex.status).set_body_json(ex.response.clone())
+        };
+
+        // Apply extra headers. Skip the `content-type` for SSE exchanges:
+        // `set_body_raw` already set the correct MIME and wiremock's
+        // `generate_response` would overwrite it anyway (insert wins over
+        // our earlier `insert_header` call).
         for (k, v) in &ex.headers {
+            if is_sse && k.eq_ignore_ascii_case("content-type") {
+                // Already handled by set_body_raw above.
+                continue;
+            }
             response = response.insert_header(k.as_str(), v.as_str());
         }
 
@@ -255,6 +289,20 @@ pub async fn mount_cassette(server: &wiremock::MockServer, cassette: &Cassette) 
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// A minimal SSE corpus: one `message_start` + one `message_stop`.
+    fn tiny_sse_corpus() -> &'static str {
+        concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_sse\",\"type\":\"message\",",
+            "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-haiku-4-5-20251001\",",
+            "\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n",
+            "\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n",
+            "\n",
+        )
+    }
 
     #[test]
     fn parse_jsonl_round_trips() {
@@ -305,5 +353,111 @@ mod tests {
         };
         let c = Cassette::from_exchanges(vec![ex]);
         assert_eq!(c.len(), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // SSE cassette round-trip tests
+    // ------------------------------------------------------------------
+
+    /// An SSE exchange serialises the wire text as a JSON string, and
+    /// round-trips through `to_jsonl` / `parse_jsonl` without corruption.
+    #[test]
+    fn sse_exchange_round_trips_through_jsonl() {
+        let sse = tiny_sse_corpus();
+        let ex = RecordedExchange {
+            method: "POST".into(),
+            path: "/v1/messages".into(),
+            status: 200,
+            request: Some(json!({"stream": true})),
+            response: json!(sse),
+            headers: vec![
+                ("content-type".into(), "text/event-stream".into()),
+                ("request-id".into(), "req_sse_1".into()),
+            ],
+        };
+
+        let cassette = Cassette::from_exchanges(vec![ex]);
+        let jsonl = cassette.to_jsonl().unwrap();
+        let again = Cassette::parse_jsonl(&jsonl).unwrap();
+
+        assert_eq!(again.len(), 1);
+        let entry = &again.exchanges()[0];
+        assert_eq!(entry.status, 200);
+        // SSE body survives the round-trip intact.
+        assert_eq!(entry.response.as_str().unwrap(), sse);
+        // Content-type header is preserved.
+        assert!(
+            entry
+                .headers
+                .iter()
+                .any(|(k, v)| k == "content-type" && v.contains("text/event-stream"))
+        );
+    }
+
+    /// `mount_cassette` on a wiremock server, then a real `Client` drives
+    /// `create_stream` against it and receives the expected SSE events.
+    #[tokio::test]
+    async fn mount_cassette_replays_sse_response() {
+        use claude_api::Client;
+        use claude_api::messages::CreateMessageRequest;
+        use claude_api::types::ModelId;
+
+        let sse = concat!(
+            "event: message_start\n",
+            "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_sse_replay\",\"type\":\"message\",",
+            "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-haiku-4-5-20251001\",",
+            "\"usage\":{\"input_tokens\":3,\"output_tokens\":0}}}\n",
+            "\n",
+            "event: content_block_start\n",
+            "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n",
+            "\n",
+            "event: content_block_delta\n",
+            "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi\"}}\n",
+            "\n",
+            "event: content_block_stop\n",
+            "data: {\"type\":\"content_block_stop\",\"index\":0}\n",
+            "\n",
+            "event: message_delta\n",
+            "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}\n",
+            "\n",
+            "event: message_stop\n",
+            "data: {\"type\":\"message_stop\"}\n",
+            "\n",
+        );
+
+        let cassette = Cassette::from_exchanges(vec![RecordedExchange {
+            method: "POST".into(),
+            path: "/v1/messages".into(),
+            status: 200,
+            request: None,
+            response: json!(sse),
+            headers: vec![("content-type".into(), "text/event-stream".into())],
+        }]);
+
+        let server = wiremock::MockServer::start().await;
+        mount_cassette(&server, &cassette).await;
+
+        let client = Client::builder()
+            .api_key("sk-ant-test")
+            .base_url(server.uri())
+            .build()
+            .unwrap();
+
+        let req = CreateMessageRequest::builder()
+            .model(ModelId::HAIKU_4_5)
+            .max_tokens(8)
+            .user("hi")
+            .build()
+            .unwrap();
+
+        let stream = client.messages().create_stream(req).await.unwrap();
+        let msg = stream.aggregate().await.unwrap();
+
+        assert_eq!(msg.id, "msg_sse_replay");
+        assert_eq!(
+            msg.stop_reason,
+            Some(claude_api::types::StopReason::EndTurn)
+        );
+        assert_eq!(msg.usage.output_tokens, 1);
     }
 }

--- a/crates/claude-api-test/src/recorder.rs
+++ b/crates/claude-api-test/src/recorder.rs
@@ -293,8 +293,25 @@ fn build_exchange(
             }),
         )
     };
-    let response_value = serde_json::from_slice::<serde_json::Value>(response_body)
-        .unwrap_or_else(|_| serde_json::Value::String(format!("<{} bytes>", response_body.len())));
+
+    // SSE responses arrive as `text/event-stream` and are not valid JSON.
+    // Store the raw wire text as a JSON string so the cassette can replay
+    // it verbatim; `mount_cassette` detects the content-type and serves
+    // the body as text rather than JSON.
+    let is_sse = response_headers
+        .get(http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.contains("text/event-stream"));
+
+    let response_value = if is_sse {
+        // Preserve SSE wire format as a plain string value.
+        let text = String::from_utf8_lossy(response_body).into_owned();
+        serde_json::Value::String(text)
+    } else {
+        serde_json::from_slice::<serde_json::Value>(response_body).unwrap_or_else(|_| {
+            serde_json::Value::String(format!("<{} bytes>", response_body.len()))
+        })
+    };
 
     let mut headers: Vec<(String, String)> = Vec::new();
     for (name, value) in response_headers {

--- a/crates/claude-api-test/tests/record_then_replay.rs
+++ b/crates/claude-api-test/tests/record_then_replay.rs
@@ -169,6 +169,137 @@ async fn recorder_redacts_auth_headers_by_default() {
     let _ = std::fs::remove_file(&tmp);
 }
 
+/// Full SSE round-trip: wiremock upstream serving `text/event-stream` ->
+/// recorder buffers + writes cassette -> cassette replayed via wiremock ->
+/// `Client::create_stream` drives the replayed SSE and aggregates the
+/// final message.
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn recorder_captures_and_replays_sse_response() {
+    use claude_api::messages::CreateMessageRequest;
+    use claude_api::types::ModelId;
+
+    let sse_body = concat!(
+        "event: message_start\n",
+        "data: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_sse_rt\",\"type\":\"message\",",
+        "\"role\":\"assistant\",\"content\":[],\"model\":\"claude-haiku-4-5-20251001\",",
+        "\"usage\":{\"input_tokens\":5,\"output_tokens\":0}}}\n",
+        "\n",
+        "event: content_block_start\n",
+        "data: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}}\n",
+        "\n",
+        "event: content_block_delta\n",
+        "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hello\"}}\n",
+        "\n",
+        "event: content_block_stop\n",
+        "data: {\"type\":\"content_block_stop\",\"index\":0}\n",
+        "\n",
+        "event: message_delta\n",
+        "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":5,\"output_tokens\":1}}\n",
+        "\n",
+        "event: message_stop\n",
+        "data: {\"type\":\"message_stop\"}\n",
+        "\n",
+    );
+
+    // 1. Stand up a wiremock server serving SSE.
+    // Use `set_body_raw` so wiremock sends `content-type: text/event-stream`;
+    // `set_body_string` would override the content-type to `text/plain`.
+    let upstream = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(sse_body.as_bytes(), "text/event-stream")
+                .insert_header("request-id", "req_sse_upstream"),
+        )
+        .mount(&upstream)
+        .await;
+
+    // 2. Boot the recorder.
+    let tmp = tempfile_path("cassette_sse_rt.jsonl");
+    let recorder = Recorder::start(RecorderConfig {
+        upstream: upstream.uri(),
+        cassette_path: tmp.clone(),
+        ..Default::default()
+    })
+    .await
+    .expect("recorder starts");
+
+    // 3. Drive `create_stream` through the recorder.
+    let client = Client::builder()
+        .api_key("sk-ant-real-secret")
+        .base_url(recorder.url())
+        .build()
+        .unwrap();
+
+    let req = CreateMessageRequest::builder()
+        .model(ModelId::HAIKU_4_5)
+        .max_tokens(8)
+        .user("hi streaming")
+        .build()
+        .unwrap();
+
+    let stream = client.messages().create_stream(req.clone()).await.unwrap();
+    let live_msg = stream.aggregate().await.unwrap();
+    assert_eq!(live_msg.id, "msg_sse_rt");
+    assert_eq!(live_msg.usage.output_tokens, 1);
+
+    recorder.shutdown().await.unwrap();
+
+    // 4. Inspect the cassette.
+    let cassette = Cassette::from_path(&tmp).await.expect("cassette loads");
+    assert_eq!(cassette.len(), 1);
+    let entry = &cassette.exchanges()[0];
+    assert_eq!(entry.method, "POST");
+    assert_eq!(entry.path, "/v1/messages");
+    assert_eq!(entry.status, 200);
+    // The SSE body should be stored as a string, not `<N bytes>`.
+    let stored = entry
+        .response
+        .as_str()
+        .expect("SSE response should be stored as a JSON string");
+    assert!(
+        stored.contains("msg_sse_rt"),
+        "cassette should contain the message id: {stored:?}",
+    );
+    assert!(
+        stored.contains("message_start"),
+        "cassette should contain SSE events: {stored:?}",
+    );
+    // content-type header must survive into the cassette.
+    assert!(
+        entry
+            .headers
+            .iter()
+            .any(|(k, v)| k == "content-type" && v.contains("text/event-stream")),
+        "content-type: text/event-stream must be in cassette headers",
+    );
+
+    // 5. Replay: mount on a fresh wiremock, drive `create_stream` again.
+    let replay_server = MockServer::start().await;
+    mount_cassette(&replay_server, &cassette).await;
+    let replay_client = Client::builder()
+        .api_key("sk-ant-test")
+        .base_url(replay_server.uri())
+        .build()
+        .unwrap();
+
+    let stream2 = replay_client.messages().create_stream(req).await.unwrap();
+    let replayed_msg = stream2.aggregate().await.unwrap();
+    assert_eq!(replayed_msg.id, "msg_sse_rt");
+    assert_eq!(replayed_msg.usage.output_tokens, 1);
+
+    match &replayed_msg.content[0] {
+        ContentBlock::Known(KnownBlock::Text { text, .. }) => {
+            assert_eq!(text, "hello");
+        }
+        other => panic!("expected text block, got {other:?}"),
+    }
+
+    let _ = std::fs::remove_file(&tmp);
+}
+
 fn tempfile_path(name: &str) -> std::path::PathBuf {
     let mut p = std::env::temp_dir();
     p.push(format!("claude_api_test_{}_{}", std::process::id(), name));


### PR DESCRIPTION
Closes #7.

## Root cause (two bugs)

**Bug 1 -- Recorder stored SSE body as a placeholder string.**
`build_exchange` in `recorder.rs` tried `serde_json::from_slice` on the SSE wire bytes. SSE is not JSON, so parsing failed and fell back to storing `"<707 bytes>"` instead of the actual event stream. Fix: detect `content-type: text/event-stream` before attempting JSON parse and store the raw wire text directly.

**Bug 2 -- `mount_cassette` served SSE body with wrong content-type.**
`mount_cassette` used `set_body_json(...)` for all exchanges. That forces `content-type: application/json`, so the client's `eventsource-stream` parser would reject it. Additionally, wiremock's `set_body_string` + `insert_header("content-type", ...)` doesn't work -- wiremock overwrites the content-type from its internal MIME field. Fix: detect SSE cassette entries by their stored `content-type` header and use `set_body_raw(bytes, "text/event-stream")` which sets both body and MIME atomically.

## Files changed

- `crates/claude-api-test/src/recorder.rs` -- SSE detection in `build_exchange`
- `crates/claude-api-test/src/lib.rs` -- `mount_cassette` SSE path + 2 new unit tests
- `crates/claude-api-test/tests/record_then_replay.rs` -- 1 new end-to-end SSE test

## Tests added

- `sse_exchange_round_trips_through_jsonl` -- cassette serializes/deserializes SSE wire text correctly
- `mount_cassette_replays_sse_response` -- replayed response carries `text/event-stream` content-type
- `recorder_captures_and_replays_sse_response` (integration) -- full round-trip: upstream SSE mock -> recorder -> cassette JSONL -> wiremock replay -> client receives events

## Quality

515 lib + 7 cassette-lib + 3 integration tests pass. Clippy clean.