### PR TITLE
feat(bedrock): typed Messages namespace via .bedrock() flag

### DIFF
--- a/crates/claude-api/examples/bedrock.rs
+++ b/crates/claude-api/examples/bedrock.rs
@@ -1,18 +1,28 @@
 //! AWS Bedrock auth: sign requests with sigv4 instead of an API key.
 //!
-//! The example reads AWS credentials from the standard environment
-//! variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
-//! `AWS_SESSION_TOKEN`, `AWS_REGION`) and sends one message through the
-//! Bedrock Anthropic endpoint.
+//! Reads AWS credentials from the standard environment variables
+//! (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional
+//! `AWS_SESSION_TOKEN`, `AWS_REGION`) and sends one message through
+//! the Bedrock Anthropic endpoint. The typed `Messages` namespace
+//! handles the URL/body shape transform when the client is built with
+//! `.bedrock()`: the request goes to `POST /model/{id}/invoke` with
+//! `anthropic_version` injected and the top-level `model` field
+//! stripped (Bedrock takes the model in the URL).
 //!
 //! ```sh
 //! AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=... AWS_REGION=us-east-1 \
 //!     cargo run --example bedrock \
-//!     --features bedrock --no-default-features --features async,rustls,streaming,bedrock
+//!     --no-default-features --features async,rustls,streaming,bedrock
 //! ```
 //!
-//! Note: Bedrock Anthropic model IDs use the `anthropic.` prefix, e.g.
-//! `anthropic.claude-sonnet-4-6-20251001-v1:0`.
+//! Bedrock Anthropic model IDs use the `anthropic.` prefix, e.g.
+//! `anthropic.claude-haiku-4-5-20251001-v1:0`. The exact list of
+//! available models depends on your AWS region and account
+//! enrollment. Newer Claude models (Haiku 4.5, Sonnet 4.6, Opus
+//! 4.x) require a cross-region *inference profile* ID (prefixed
+//! `us.` or `global.`) rather than the bare foundation model ID.
+//! Run `aws bedrock list-inference-profiles` to discover what's
+//! available in your region.
 
 use std::sync::Arc;
 
@@ -28,20 +38,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .ok_or("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set")?;
     let signer = BedrockSigner::new(creds, &region);
 
-    // The Bedrock base URL routes to the regional endpoint.
     let base_url = format!("https://bedrock-runtime.{region}.amazonaws.com");
 
     let client = Client::builder()
+        .api_key("placeholder-bedrock-uses-sigv4")
         .signer(Arc::new(signer))
         .base_url(base_url)
+        .bedrock()
         .build()?;
 
-    // Bedrock model IDs use the full Amazon resource name format.
-    let model = "anthropic.claude-3-5-sonnet-20241022-v2:0";
+    let model =
+        std::env::var("BEDROCK_MODEL").unwrap_or_else(|_| "us.anthropic.claude-sonnet-4-6".into());
 
     let request = CreateMessageRequest::builder()
         .model(model)
-        .max_tokens(256)
+        .max_tokens(64)
         .user("What is 2 + 2?")
         .build()?;
 

--- a/crates/claude-api/src/bedrock.rs
+++ b/crates/claude-api/src/bedrock.rs
@@ -1,18 +1,6 @@
 //! AWS Bedrock support: a [`RequestSigner`] that signs HTTP requests
-//! with sigv4.
-//!
-//! `claude-api` is the Anthropic API client; this module exposes the
-//! signing primitive only. Users who want to talk to Bedrock Anthropic
-//! models still need to:
-//!
-//! 1. Set `Client::builder().base_url("https://bedrock-runtime.{region}.amazonaws.com")`,
-//! 2. Use Bedrock's URL shape (`/model/{model_id}/invoke`),
-//! 3. Inject `anthropic_version: "bedrock-2023-05-31"` and remove the
-//!    `model` field from the body (Bedrock takes the model in the URL).
-//!
-//! The typed namespace handles still use Anthropic's URL shape; Bedrock
-//! model IDs and the `anthropic_version` header must be supplied by the
-//! caller. See `examples/bedrock.rs` for a complete working sketch.
+//! with sigv4, plus the `.bedrock()` builder flag that drives the
+//! typed `Messages` namespace through Bedrock's URL/body shape.
 //!
 //! Gated on the `bedrock` feature.
 //!
@@ -26,12 +14,30 @@
 //! let creds = BedrockCredentials::from_env()
 //!     .expect("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set");
 //! let client = Client::builder()
+//!     .api_key("placeholder-bedrock-uses-sigv4")
 //!     .signer(Arc::new(BedrockSigner::new(creds, &region)))
 //!     .base_url(format!("https://bedrock-runtime.{region}.amazonaws.com"))
+//!     .bedrock()
 //!     .build()?;
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! With `.bedrock()` set, `client.messages().create(...)` posts to
+//! `/model/{model_id}/invoke` (instead of `/v1/messages`) and the
+//! request body has `model` stripped and `anthropic_version:
+//! "bedrock-2023-05-31"` injected automatically.
+//!
+//! Streaming and `count_tokens` are not yet supported on Bedrock and
+//! return [`Error::InvalidConfig`](crate::Error::InvalidConfig).
+//! Bedrock's streaming endpoint
+//! (`invoke-with-response-stream`) emits AWS event-stream binary
+//! frames rather than SSE; decoding them is a separate task.
+//!
+//! Bedrock model IDs use the `anthropic.` prefix, e.g.
+//! `anthropic.claude-haiku-4-5-20251001-v1:0`. Newer Claude models
+//! require a cross-region inference profile ID (prefixed `us.` or
+//! `global.`).
 
 #![cfg(feature = "bedrock")]
 #![cfg_attr(docsrs, doc(cfg(feature = "bedrock")))]

--- a/crates/claude-api/src/client.rs
+++ b/crates/claude-api/src/client.rs
@@ -29,6 +29,8 @@ struct Inner {
     betas: Vec<String>,
     retry: RetryPolicy,
     signer: Arc<dyn RequestSigner>,
+    #[cfg(feature = "bedrock")]
+    bedrock: bool,
 }
 
 impl Client {
@@ -280,6 +282,13 @@ impl Client {
         &self.inner.betas
     }
 
+    /// `true` if this client was built via [`ClientBuilder::bedrock`] and
+    /// should target the AWS Bedrock URL/body shape on Messages calls.
+    #[cfg(feature = "bedrock")]
+    pub(crate) fn is_bedrock(&self) -> bool {
+        self.inner.bedrock
+    }
+
     /// Materialize a request without sending it, for use by namespace-level
     /// `dry_run` helpers. Mirrors the header logic in
     /// [`Self::execute`]/[`Self::execute_streaming`] so the rendered
@@ -359,20 +368,24 @@ pub struct ClientBuilder {
     retry: Option<RetryPolicy>,
     http: Option<reqwest::Client>,
     signer: Option<Arc<dyn RequestSigner>>,
+    #[cfg(feature = "bedrock")]
+    bedrock: bool,
 }
 
 impl std::fmt::Debug for ClientBuilder {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ClientBuilder")
-            .field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
+        let mut d = f.debug_struct("ClientBuilder");
+        d.field("api_key", &self.api_key.as_ref().map(|_| "<redacted>"))
             .field("base_url", &self.base_url)
             .field("user_agent", &self.user_agent)
             .field("timeout", &self.timeout)
             .field("betas", &self.betas)
             .field("retry", &self.retry)
             .field("http", &self.http.is_some())
-            .field("signer", &self.signer.as_ref().map(|s| format!("{s:?}")))
-            .finish()
+            .field("signer", &self.signer.as_ref().map(|s| format!("{s:?}")));
+        #[cfg(feature = "bedrock")]
+        d.field("bedrock", &self.bedrock);
+        d.finish()
     }
 }
 
@@ -442,6 +455,28 @@ impl ClientBuilder {
         self
     }
 
+    /// Configure this client to target the AWS Bedrock URL/body shape
+    /// rather than the Anthropic API.
+    ///
+    /// In Bedrock mode, [`Messages::create`](crate::messages::Messages::create)
+    /// rewrites the request to:
+    ///
+    /// - URL: `POST /model/{model_id}/invoke` (vs `POST /v1/messages`)
+    /// - Body: drops the top-level `model` field (it lives in the URL)
+    ///   and injects `anthropic_version: "bedrock-2023-05-31"`
+    ///
+    /// You still need to set the regional Bedrock base URL and install
+    /// a [`BedrockSigner`](crate::bedrock::BedrockSigner) via
+    /// [`Self::signer`]. Streaming and `count_tokens` are not supported
+    /// in Bedrock mode and will return [`Error::InvalidConfig`].
+    #[cfg(feature = "bedrock")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "bedrock")))]
+    #[must_use]
+    pub fn bedrock(mut self) -> Self {
+        self.bedrock = true;
+        self
+    }
+
     /// Construct the [`Client`]. Returns [`Error::InvalidConfig`] if
     /// neither an `api_key` nor a custom `signer` was provided.
     pub fn build(self) -> Result<Client> {
@@ -476,6 +511,8 @@ impl ClientBuilder {
             betas: self.betas,
             retry: self.retry.unwrap_or_default(),
             signer,
+            #[cfg(feature = "bedrock")]
+            bedrock: self.bedrock,
         };
 
         Ok(Client {

--- a/crates/claude-api/src/messages/api.rs
+++ b/crates/claude-api/src/messages/api.rs
@@ -41,6 +41,29 @@ use crate::messages::response::{CountTokensResponse, Message};
 #[cfg(feature = "streaming")]
 use crate::messages::stream::EventStream;
 
+/// `anthropic_version` value Bedrock expects in the request body
+/// (see <https://docs.anthropic.com/en/api/claude-on-amazon-bedrock>).
+#[cfg(feature = "bedrock")]
+const BEDROCK_ANTHROPIC_VERSION: &str = "bedrock-2023-05-31";
+
+/// Reshape a [`CreateMessageRequest`] for the Bedrock `InvokeModel` body:
+/// strip the top-level `model` field (Bedrock takes the model in the
+/// URL) and inject `anthropic_version`. Returns the rewritten body and
+/// the original model identifier (for the URL path).
+#[cfg(feature = "bedrock")]
+fn bedrock_payload(request: &CreateMessageRequest) -> Result<(String, serde_json::Value)> {
+    let model_id = request.model.as_str().to_owned();
+    let mut value = serde_json::to_value(request)?;
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("model");
+        obj.insert(
+            "anthropic_version".to_owned(),
+            serde_json::Value::String(BEDROCK_ANTHROPIC_VERSION.to_owned()),
+        );
+    }
+    Ok((model_id, value))
+}
+
 /// Namespace handle for the Messages API.
 ///
 /// Obtained via [`Client::messages`](crate::Client::messages); cheap to
@@ -69,6 +92,24 @@ impl<'a> Messages<'a> {
         request: CreateMessageRequest,
         betas: &[&str],
     ) -> Result<Message> {
+        #[cfg(feature = "bedrock")]
+        if self.client.is_bedrock() {
+            let (model_id, body) = bedrock_payload(&request)?;
+            let path = format!("/model/{model_id}/invoke");
+            let body_ref = &body;
+            return self
+                .client
+                .execute_with_retry(
+                    || {
+                        self.client
+                            .request_builder(reqwest::Method::POST, &path)
+                            .json(body_ref)
+                    },
+                    betas,
+                )
+                .await;
+        }
+
         let request_ref = &request;
         self.client
             .execute_with_retry(
@@ -94,6 +135,12 @@ impl<'a> Messages<'a> {
         request: CountTokensRequest,
         betas: &[&str],
     ) -> Result<CountTokensResponse> {
+        #[cfg(feature = "bedrock")]
+        if self.client.is_bedrock() {
+            return Err(crate::error::Error::InvalidConfig(
+                "count_tokens is not available on Bedrock".into(),
+            ));
+        }
         let request_ref = &request;
         self.client
             .execute_with_retry(
@@ -122,6 +169,16 @@ impl<'a> Messages<'a> {
         request: &CreateMessageRequest,
         betas: &[&str],
     ) -> Result<DryRun> {
+        #[cfg(feature = "bedrock")]
+        if self.client.is_bedrock() {
+            let (model_id, body) = bedrock_payload(request)?;
+            let path = format!("/model/{model_id}/invoke");
+            let builder = self
+                .client
+                .request_builder(reqwest::Method::POST, &path)
+                .json(&body);
+            return self.client.render_dry_run(builder, betas);
+        }
         let builder = self
             .client
             .request_builder(reqwest::Method::POST, "/v1/messages")
@@ -269,6 +326,15 @@ impl<'a> Messages<'a> {
         mut request: CreateMessageRequest,
         betas: &[&str],
     ) -> Result<EventStream> {
+        #[cfg(feature = "bedrock")]
+        if self.client.is_bedrock() {
+            // Bedrock's `invoke-with-response-stream` uses the AWS event
+            // stream binary protocol, not SSE. Decoding it requires a
+            // separate parser; not yet supported.
+            return Err(crate::error::Error::InvalidConfig(
+                "streaming is not yet supported on Bedrock (uses AWS event stream, not SSE)".into(),
+            ));
+        }
         request.stream = true;
         let response = self
             .client
@@ -928,5 +994,154 @@ mod tests {
         // The body matcher above is the actual assertion; if `stream: true`
         // wasn't sent, the mock would 404.
         let _ = client.messages().create_stream(req).await.unwrap();
+    }
+
+    // ---------------- Bedrock mode ----------------
+
+    #[cfg(feature = "bedrock")]
+    fn bedrock_client_for(mock: &MockServer) -> Client {
+        Client::builder()
+            .api_key("placeholder")
+            .base_url(mock.uri())
+            .bedrock()
+            .build()
+            .unwrap()
+    }
+
+    #[cfg(feature = "bedrock")]
+    #[tokio::test]
+    async fn bedrock_create_rewrites_url_to_invoke_path() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/model/anthropic.claude-haiku-4-5-20251001/invoke"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg_bedrock", "type": "message", "role": "assistant",
+                "model": "anthropic.claude-haiku-4-5-20251001",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 1}
+            })))
+            .expect(1)
+            .mount(&mock)
+            .await;
+
+        let client = bedrock_client_for(&mock);
+        let req = CreateMessageRequest::builder()
+            .model("anthropic.claude-haiku-4-5-20251001")
+            .max_tokens(8)
+            .user("hi")
+            .build()
+            .unwrap();
+        let resp: Message = client.messages().create(req).await.unwrap();
+        assert_eq!(resp.id, "msg_bedrock");
+    }
+
+    #[cfg(feature = "bedrock")]
+    #[tokio::test]
+    async fn bedrock_create_rewrites_body_drops_model_adds_anthropic_version() {
+        let mock = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/model/anthropic.claude-haiku-4-5-20251001/invoke"))
+            .and(body_partial_json(json!({
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": 8,
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "id": "msg_b", "type": "message", "role": "assistant",
+                "model": "anthropic.claude-haiku-4-5-20251001",
+                "content": [{"type": "text", "text": "ok"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 5, "output_tokens": 1}
+            })))
+            .mount(&mock)
+            .await;
+
+        let client = bedrock_client_for(&mock);
+        let req = CreateMessageRequest::builder()
+            .model("anthropic.claude-haiku-4-5-20251001")
+            .max_tokens(8)
+            .user("hi")
+            .build()
+            .unwrap();
+        client.messages().create(req).await.unwrap();
+
+        // Inspect the captured body: `model` must be absent, since
+        // body_partial_json only enforces presence of named fields.
+        let received = &mock.received_requests().await.unwrap()[0];
+        let body: serde_json::Value = serde_json::from_slice(&received.body).unwrap();
+        assert!(
+            body.get("model").is_none(),
+            "Bedrock body must not include top-level `model`: {body}"
+        );
+        assert_eq!(
+            body.get("anthropic_version").and_then(|v| v.as_str()),
+            Some("bedrock-2023-05-31"),
+        );
+    }
+
+    #[cfg(feature = "bedrock")]
+    #[tokio::test]
+    async fn bedrock_count_tokens_returns_invalid_config() {
+        // Mock will never be hit; if it is, we'll see a 404 from the
+        // unmounted path and the assertion below would change.
+        let mock = MockServer::start().await;
+        let client = bedrock_client_for(&mock);
+        let req = CountTokensRequest::builder()
+            .model("anthropic.claude-haiku-4-5-20251001")
+            .user("hi")
+            .build()
+            .unwrap();
+        let err = client.messages().count_tokens(req).await.unwrap_err();
+        assert!(
+            matches!(err, crate::error::Error::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+    }
+
+    #[cfg(all(feature = "bedrock", feature = "streaming"))]
+    #[tokio::test]
+    async fn bedrock_create_stream_returns_invalid_config() {
+        let mock = MockServer::start().await;
+        let client = bedrock_client_for(&mock);
+        let req = CreateMessageRequest::builder()
+            .model("anthropic.claude-haiku-4-5-20251001")
+            .max_tokens(8)
+            .user("hi")
+            .build()
+            .unwrap();
+        let err = client.messages().create_stream(req).await.unwrap_err();
+        assert!(
+            matches!(err, crate::error::Error::InvalidConfig(_)),
+            "expected InvalidConfig, got {err:?}"
+        );
+    }
+
+    #[cfg(feature = "bedrock")]
+    #[test]
+    fn bedrock_dry_run_renders_invoke_url_and_rewritten_body() {
+        let client = Client::builder()
+            .api_key("placeholder")
+            .base_url("https://bedrock-runtime.us-east-1.amazonaws.com")
+            .bedrock()
+            .build()
+            .unwrap();
+        let req = CreateMessageRequest::builder()
+            .model("anthropic.claude-haiku-4-5-20251001")
+            .max_tokens(8)
+            .user("hi")
+            .build()
+            .unwrap();
+        let dry = client.messages().dry_run(&req).unwrap();
+        assert!(
+            dry.url
+                .ends_with("/model/anthropic.claude-haiku-4-5-20251001/invoke"),
+            "url={}",
+            dry.url
+        );
+        assert!(dry.body.get("model").is_none(), "body={}", dry.body);
+        assert_eq!(
+            dry.body.get("anthropic_version").and_then(|v| v.as_str()),
+            Some("bedrock-2023-05-31"),
+        );
     }
 }

--- a/crates/claude-api/tests/bedrock_live.rs
+++ b/crates/claude-api/tests/bedrock_live.rs
@@ -3,17 +3,34 @@
 //! Skipped by default; run via:
 //!
 //! ```sh
-//! BEDROCK_INTEGRATION=1 \
+//! CLAUDE_API_BEDROCK_LIVE=1 \
 //! AWS_ACCESS_KEY_ID=... \
 //! AWS_SECRET_ACCESS_KEY=... \
-//! BEDROCK_REGION=us-east-1 \
-//! BEDROCK_MODEL=anthropic.claude-3-5-sonnet-20240620-v1:0 \
-//!   cargo test --features bedrock --test bedrock_live -- --nocapture
+//! AWS_REGION=us-east-1 \
+//! BEDROCK_MODEL=us.anthropic.claude-sonnet-4-6 \
+//!   cargo test --no-default-features \
+//!     --features async,rustls,streaming,bedrock \
+//!     --test bedrock_live -- --nocapture
 //! ```
 //!
-//! The test issues a single `InvokeModel` call and asserts the request was
-//! signed correctly (the response body shape is incidental). Cost is one
-//! short request -- a few cents at most.
+//! Drives a single `Messages::create` call through the typed client
+//! against the regional Bedrock endpoint. The `.bedrock()` builder
+//! flag rewrites the URL to `/model/{id}/invoke` and rewrites the
+//! body to drop `model` + add `anthropic_version`. Cost is one short
+//! request -- a few cents at most.
+//!
+//! Bedrock model access is enrolled per-account in the AWS console;
+//! a 403 `AccessDeniedException` here means the model isn't enabled
+//! in this account/region. Newer Claude models (Haiku 4.5, Sonnet
+//! 4.6, Opus 4.x) require a cross-region *inference profile* ID
+//! (prefixed `us.` or `global.`) rather than the bare foundation
+//! model ID; sending the bare ID returns a 400 with the message
+//! "Invocation of model ID ... with on-demand throughput isn't
+//! supported." Some Anthropic models on Bedrock additionally require
+//! a one-time use-case form submission (returns a 404 with the
+//! message "Model use case details have not been submitted for this
+//! account."). Run `aws bedrock list-inference-profiles` to discover
+//! what's available in your region.
 
 #![cfg(feature = "bedrock")]
 
@@ -21,70 +38,68 @@ use std::env;
 use std::sync::Arc;
 
 use claude_api::Client;
-use claude_api::auth::RequestSigner;
 use claude_api::bedrock::{BedrockCredentials, BedrockSigner};
+use claude_api::messages::{ContentBlock, CreateMessageRequest, KnownBlock};
+
+const ENV_LIVE: &str = "CLAUDE_API_BEDROCK_LIVE";
 
 fn skip_unless_opt_in() -> bool {
-    env::var("BEDROCK_INTEGRATION").as_deref() != Ok("1")
+    env::var(ENV_LIVE).as_deref() != Ok("1")
 }
 
 #[tokio::test]
-async fn live_bedrock_invoke_model() {
+async fn live_bedrock_messages_create() {
     if skip_unless_opt_in() {
-        eprintln!("skipped: set BEDROCK_INTEGRATION=1 to run");
+        eprintln!("skipped: set {ENV_LIVE}=1 to run");
         return;
     }
 
-    let region = env::var("BEDROCK_REGION").unwrap_or_else(|_| "us-east-1".into());
-    let model = env::var("BEDROCK_MODEL")
-        .unwrap_or_else(|_| "anthropic.claude-3-5-sonnet-20240620-v1:0".into());
+    let region = env::var("AWS_REGION").unwrap_or_else(|_| "us-east-1".into());
+    let model =
+        env::var("BEDROCK_MODEL").unwrap_or_else(|_| "us.anthropic.claude-sonnet-4-6".into());
     let creds = BedrockCredentials::from_env()
         .expect("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set");
-    let signer = Arc::new(BedrockSigner::new(creds, region.clone()));
 
     let base_url = format!("https://bedrock-runtime.{region}.amazonaws.com");
     let client = Client::builder()
         .api_key("placeholder-bedrock-uses-sigv4")
         .base_url(&base_url)
-        .signer(signer)
+        .signer(Arc::new(BedrockSigner::new(creds, region)))
+        .bedrock()
         .build()
         .expect("client builds");
 
-    // Bedrock InvokeModel: POST /model/{modelId}/invoke. Body uses
-    // Bedrock's `anthropic_version` instead of the date-based one and
-    // omits the `model` field (which is in the URL).
-    let body = serde_json::json!({
-        "anthropic_version": "bedrock-2023-05-31",
-        "max_tokens": 16,
-        "messages": [{"role": "user", "content": "Say hello in one word."}]
-    });
-
-    // We don't go through the typed namespace because Bedrock's URL
-    // shape differs from the Anthropic API. Use the low-level execute
-    // path directly via reqwest.
-    let raw = reqwest::Client::new();
-    let mut request = raw
-        .post(format!("{base_url}/model/{model}/invoke"))
-        .header("content-type", "application/json")
-        .header("accept", "application/json")
-        .body(body.to_string())
+    let req = CreateMessageRequest::builder()
+        .model(model)
+        .max_tokens(16)
+        .user("Say hello in one word.")
         .build()
-        .expect("request builds");
-    let signer = BedrockSigner::new(BedrockCredentials::from_env().unwrap(), region);
-    signer.sign(&mut request).expect("sign succeeds");
+        .expect("build request");
 
-    let resp = raw.execute(request).await.expect("request sends");
-    let status = resp.status();
-    let text = resp.text().await.unwrap_or_default();
+    let resp = client
+        .messages()
+        .create(req)
+        .await
+        .expect("Bedrock InvokeModel succeeds");
+
+    eprintln!("Bedrock response: {resp:#?}");
+
+    assert_eq!(resp.kind, "message");
+    assert!(!resp.content.is_empty(), "content should not be empty");
     assert!(
-        status.is_success(),
-        "Bedrock InvokeModel failed: {status}\n{text}",
+        resp.content
+            .iter()
+            .any(|b| matches!(b, ContentBlock::Known(KnownBlock::Text { .. }))),
+        "expected at least one text block",
     );
-    eprintln!("Bedrock response: {text}");
-
-    // Don't actually use `client` for this round-trip; the URL shape
-    // mismatch makes that a v0.5 namespace problem. The test is
-    // verifying that BedrockSigner produces signatures the real
-    // Bedrock service accepts.
-    let _ = client;
+    assert!(
+        resp.usage.input_tokens > 0,
+        "input_tokens={}",
+        resp.usage.input_tokens,
+    );
+    assert!(
+        resp.usage.output_tokens > 0,
+        "output_tokens={}",
+        resp.usage.output_tokens,
+    );
 }


### PR DESCRIPTION
## Summary

Closes #34. Bedrock-hosted Claude models now work through the typed `client.messages().create(...)` path instead of raw reqwest.

`ClientBuilder` gains a `.bedrock()` opt-in (gated on the `bedrock` feature). When set, `Messages::create` and `Messages::dry_run`:
- Rewrite the URL: `POST /model/{model_id}/invoke` (was `/v1/messages`)
- Rewrite the body: strip top-level `model`, inject `anthropic_version: "bedrock-2023-05-31"`

`Messages::create_stream` and `Messages::count_tokens` return `Error::InvalidConfig` in Bedrock mode (Bedrock's `invoke-with-response-stream` uses AWS event-stream binary frames, not SSE; `count_tokens` doesn't exist on Bedrock).

## Verification

Run end-to-end against real AWS Bedrock (us-east-1, `us.anthropic.claude-sonnet-4-6` inference profile):

```
StopReason::EndTurn
Usage { input_tokens: 13, output_tokens: 5, ... }
```

Typed `Message` decodes correctly through the rewritten path.

## Test plan

- [x] 5 new wiremock unit tests in `messages/api.rs::tests`: URL rewrite, body rewrite (model dropped, anthropic_version injected), `dry_run` mirrors transform, `count_tokens`/`create_stream` return `InvalidConfig`
- [x] `tests/bedrock_live.rs` rewritten to use the typed path with assertions on `Message.kind`, `Message.content` (text block present), `Message.usage` (input + output tokens > 0); env var renamed to `CLAUDE_API_BEDROCK_LIVE` for consistency
- [x] Live test executed against real AWS (us-east-1, Sonnet 4.6) -- typed response decoded successfully
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-features --all-targets -- -D warnings` clean
- [x] 535 lib tests pass
- [x] Feature matrix builds clean: `--no-default-features`, `async,rustls,streaming`, `async,rustls,streaming,bedrock`, `sync,rustls`

## Notes

- `examples/bedrock.rs` updated to use `.bedrock()` (the example previously claimed it worked through the typed path but it didn't -- old example was broken)
- `bedrock.rs` module docs rewritten to reflect the new builder method
- Newer Claude models on Bedrock require a cross-region inference profile ID (`us.` or `global.` prefix) instead of the bare foundation model ID; documented in test/example/module docs