### PR TITLE
chore: release v0.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "claude-api"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "aws-credential-types",
@@ -303,7 +303,7 @@ dependencies = [
 
 [[package]]
 name = "claude-api-test"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "bytes",
  "claude-api",

--- a/crates/claude-api-test/CHANGELOG.md
+++ b/crates/claude-api-test/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `claude-api-test` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and uses [Semantic Versioning](https://semver.org/).
 
+## [0.5.4](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.3...claude-api-test-v0.5.4) - 2026-05-02
+
+### Other
+
+- updated the following local packages: claude-api
+
 ## [0.5.3](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.2...claude-api-test-v0.5.3) - 2026-05-02
 
 ### Added

--- a/crates/claude-api-test/CHANGELOG.md
+++ b/crates/claude-api-test/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `claude-api-test` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and uses [Semantic Versioning](https://semver.org/).
 
+## [0.5.4](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.3...claude-api-test-v0.5.4) - 2026-06-12
+
+### Other
+
+- updated the following local packages: claude-api
+
 ## [0.5.3](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.2...claude-api-test-v0.5.3) - 2026-05-02
 
 ### Added

--- a/crates/claude-api-test/Cargo.toml
+++ b/crates/claude-api-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-api-test"
-version = "0.5.3"
+version = "0.5.4"
 description = "Test utilities for claude-api: cassette-based replay of recorded HTTP exchanges"
 documentation = "https://docs.rs/claude-api-test"
 edition.workspace = true
@@ -21,7 +21,7 @@ reqwest = { workspace = true, features = ["rustls-tls"] }
 bytes = { workspace = true }
 
 [dev-dependencies]
-claude-api = { version = "0.5.3", path = "../claude-api", default-features = false, features = ["async", "rustls", "streaming", "skills", "user-profiles", "managed-agents-preview", "admin", "conversation"] }
+claude-api = { version = "0.5.4", path = "../claude-api", default-features = false, features = ["async", "rustls", "streaming", "skills", "user-profiles", "managed-agents-preview", "admin", "conversation"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 pretty_assertions = { workspace = true }
 

--- a/crates/claude-api/CHANGELOG.md
+++ b/crates/claude-api/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `claude-api`, `claude-api-derive`, and
 Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.4](https://github.com/joshrotenberg/claude-api/compare/v0.5.3...v0.5.4) - 2026-05-02
+
+### Added
+
+- *(bedrock)* typed Messages namespace via .bedrock() flag ([#40](https://github.com/joshrotenberg/claude-api/pull/40))
+
 ## [0.5.3](https://github.com/joshrotenberg/claude-api/compare/v0.5.2...v0.5.3) - 2026-05-02
 
 ### Added

--- a/crates/claude-api/CHANGELOG.md
+++ b/crates/claude-api/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to `claude-api`, `claude-api-derive`, and
 Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 [Semantic Versioning](https://semver.org/).
 
+## [0.5.4](https://github.com/joshrotenberg/claude-api/compare/v0.5.3...v0.5.4) - 2026-06-12
+
+### Added
+
+- *(messages)* output_config -- structured outputs, effort, task budget ([#60](https://github.com/joshrotenberg/claude-api/pull/60))
+- adaptive thinking + Opus 4.8 / Fable 5 model constants ([#59](https://github.com/joshrotenberg/claude-api/pull/59))
+- *(bedrock)* typed Messages namespace via .bedrock() flag ([#40](https://github.com/joshrotenberg/claude-api/pull/40))
+
+### Fixed
+
+- *(examples)* declare required-features for bedrock, managed_agents, batches ([#58](https://github.com/joshrotenberg/claude-api/pull/58))
+
+### Other
+
+- correct vertex feature note + sampling-param model notes ([#61](https://github.com/joshrotenberg/claude-api/pull/61))
+
 ## [0.5.3](https://github.com/joshrotenberg/claude-api/compare/v0.5.2...v0.5.3) - 2026-05-02
 
 ### Added

--- a/crates/claude-api/Cargo.toml
+++ b/crates/claude-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-api"
-version = "0.5.3"
+version = "0.5.4"
 description = "Type-safe Rust client for the Anthropic API"
 keywords = ["anthropic", "claude", "api", "ai", "llm"]
 categories = ["api-bindings", "asynchronous"]


### PR DESCRIPTION



## 🤖 New release

* `claude-api`: 0.5.3 -> 0.5.4 (✓ API compatible changes)
* `claude-api-test`: 0.5.3 -> 0.5.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `claude-api`

<blockquote>

## [0.5.4](https://github.com/joshrotenberg/claude-api/compare/v0.5.3...v0.5.4) - 2026-06-12

### Added

- *(messages)* output_config -- structured outputs, effort, task budget ([#60](https://github.com/joshrotenberg/claude-api/pull/60))
- adaptive thinking + Opus 4.8 / Fable 5 model constants ([#59](https://github.com/joshrotenberg/claude-api/pull/59))
- *(bedrock)* typed Messages namespace via .bedrock() flag ([#40](https://github.com/joshrotenberg/claude-api/pull/40))

### Fixed

- *(examples)* declare required-features for bedrock, managed_agents, batches ([#58](https://github.com/joshrotenberg/claude-api/pull/58))

### Other

- correct vertex feature note + sampling-param model notes ([#61](https://github.com/joshrotenberg/claude-api/pull/61))
</blockquote>

## `claude-api-test`

<blockquote>

## [0.5.4](https://github.com/joshrotenberg/claude-api/compare/claude-api-test-v0.5.3...claude-api-test-v0.5.4) - 2026-06-12

### Other

- updated the following local packages: claude-api
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).