### PR TITLE
fix(examples): declare required-features for bedrock, managed_agents, batches

### DIFF
--- a/crates/claude-api/Cargo.toml
+++ b/crates/claude-api/Cargo.toml
@@ -125,6 +125,18 @@ required-features = ["async", "conversation", "derive"]
 name = "blocking"
 required-features = ["sync"]
 
+[[example]]
+name = "batches"
+required-features = ["async"]
+
+[[example]]
+name = "bedrock"
+required-features = ["async", "bedrock"]
+
+[[example]]
+name = "managed_agents"
+required-features = ["async", "managed-agents-preview"]
+
 [lints.rust]
 unsafe_code = "forbid"
 missing_docs = "warn"


### PR DESCRIPTION
## Problem

`bedrock`, `managed_agents`, and `batches` had no `[[example]]` entries in `crates/claude-api/Cargo.toml`, so Cargo auto-discovered them with no `required-features` and compiled them under default features. The `bedrock` module is gated on the `bedrock` feature and `managed_agents` on `managed-agents-preview`, so `cargo check/build --all-targets` (and `--workspace`) failed on default features.

## Fix

Add explicit `[[example]]` entries:

- `batches`: `["async"]`
- `bedrock`: `["async", "bedrock"]`
- `managed_agents`: `["async", "managed-agents-preview"]`

## Verification

- `cargo check --all-targets` (default features): passes -- the two feature-gated examples are now correctly skipped.
- `cargo check --all-targets --all-features`: passes -- all examples compile.

Closes #48.

Also reported in #43, #44, #45, #46, #47, #49, #50, #51 -- closing those as duplicates of #48.