### PR TITLE
feat: adaptive thinking + Opus 4.8 / Fable 5 model constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .messages()
         .create(
             CreateMessageRequest::builder()
-                .model(ModelId::SONNET_4_6)
+                .model(ModelId::OPUS_4_8)
                 .max_tokens(256)
                 .system("Be concise.")
                 .user("What is the capital of France?")

--- a/crates/claude-api/src/lib.rs
+++ b/crates/claude-api/src/lib.rs
@@ -18,7 +18,7 @@
 //!     .messages()
 //!     .create(
 //!         CreateMessageRequest::builder()
-//!             .model(ModelId::SONNET_4_6)
+//!             .model(ModelId::OPUS_4_8)
 //!             .max_tokens(256)
 //!             .user("Hello!")
 //!             .build()?,

--- a/crates/claude-api/src/messages/thinking.rs
+++ b/crates/claude-api/src/messages/thinking.rs
@@ -1,29 +1,43 @@
 //! Configuration for extended thinking.
 //!
-//! Pass a [`ThinkingConfig::Enabled`] value in the request to have the model
-//! emit `thinking` blocks before its final answer. `budget_tokens` caps how
-//! much of `max_tokens` the model may spend on reasoning.
+//! Pass a [`ThinkingConfig`] value in the request to have the model emit
+//! `thinking` blocks before its final answer. Two modes are available:
 //!
-//! Extended thinking is supported by Claude Sonnet 4.6+ and Claude Opus 4.x.
+//! - [`ThinkingConfig::Adaptive`] lets the model decide how much to think.
+//!   This is the only accepted mode on Claude Opus 4.7+ and Fable 5, which
+//!   reject `budget_tokens` with HTTP 400.
+//! - [`ThinkingConfig::Enabled`] caps reasoning at an explicit `budget_tokens`
+//!   (counted against `max_tokens`). Supported on Claude Sonnet 4.6 and
+//!   earlier Opus models.
+//!
 //! See [`crate::models::ModelCapabilities`] to check model support at runtime.
 
 use serde::{Deserialize, Serialize};
 
 /// Whether and how the model should produce extended-thinking output.
 ///
-/// When [`ThinkingConfig::Enabled`], the model emits one or more
+/// When thinking is on, the model emits one or more
 /// [`Thinking`](crate::messages::content::KnownBlock::Thinking) blocks
-/// before its final answer. `budget_tokens` caps the thinking length;
-/// it counts against `max_tokens`.
+/// before its final answer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[non_exhaustive]
 pub enum ThinkingConfig {
     /// Enable extended thinking with a per-turn token budget.
+    ///
+    /// `budget_tokens` caps the thinking length and counts against
+    /// `max_tokens`. Supported on Claude Sonnet 4.6 and earlier Opus models;
+    /// Claude Opus 4.7+ and Fable 5 reject it with HTTP 400 -- use
+    /// [`ThinkingConfig::Adaptive`] there instead.
     Enabled {
         /// Maximum tokens the model may spend thinking on this turn.
         budget_tokens: u32,
     },
+    /// Enable extended thinking and let the model decide how much to think.
+    ///
+    /// The only accepted thinking mode on Claude Opus 4.7+ and Fable 5.
+    /// Serializes to `{"type": "adaptive"}`.
+    Adaptive,
     /// Disable extended thinking explicitly.
     Disabled,
 }
@@ -33,6 +47,15 @@ impl ThinkingConfig {
     #[must_use]
     pub fn enabled(budget_tokens: u32) -> Self {
         Self::Enabled { budget_tokens }
+    }
+
+    /// Convenience constructor for the [`ThinkingConfig::Adaptive`] variant.
+    ///
+    /// Use this on Claude Opus 4.7+ and Fable 5, which do not accept
+    /// `budget_tokens`.
+    #[must_use]
+    pub fn adaptive() -> Self {
+        Self::Adaptive
     }
 }
 
@@ -47,6 +70,15 @@ mod tests {
         let c = ThinkingConfig::enabled(8192);
         let v = serde_json::to_value(c).unwrap();
         assert_eq!(v, json!({"type": "enabled", "budget_tokens": 8192}));
+        let parsed: ThinkingConfig = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed, c);
+    }
+
+    #[test]
+    fn adaptive_round_trips() {
+        let c = ThinkingConfig::adaptive();
+        let v = serde_json::to_value(c).unwrap();
+        assert_eq!(v, json!({"type": "adaptive"}));
         let parsed: ThinkingConfig = serde_json::from_value(v).unwrap();
         assert_eq!(parsed, c);
     }

--- a/crates/claude-api/src/types.rs
+++ b/crates/claude-api/src/types.rs
@@ -31,6 +31,10 @@ use serde::{Deserialize, Serialize};
 pub struct ModelId(Cow<'static, str>);
 
 impl ModelId {
+    /// Claude Fable 5, the most capable model (top tier above Opus).
+    pub const FABLE_5: ModelId = ModelId(Cow::Borrowed("claude-fable-5"));
+    /// Claude Opus 4.8.
+    pub const OPUS_4_8: ModelId = ModelId(Cow::Borrowed("claude-opus-4-8"));
     /// Claude Opus 4.7.
     pub const OPUS_4_7: ModelId = ModelId(Cow::Borrowed("claude-opus-4-7"));
     /// Claude Sonnet 4.6.
@@ -209,6 +213,8 @@ mod tests {
 
     #[test]
     fn model_id_serializes_as_string() {
+        round_trip(&ModelId::FABLE_5, "\"claude-fable-5\"");
+        round_trip(&ModelId::OPUS_4_8, "\"claude-opus-4-8\"");
         round_trip(&ModelId::OPUS_4_7, "\"claude-opus-4-7\"");
         round_trip(&ModelId::SONNET_4_6, "\"claude-sonnet-4-6\"");
         round_trip(&ModelId::HAIKU_4_5, "\"claude-haiku-4-5-20251001\"");


### PR DESCRIPTION
Makes the crate correct on current flagship models.

## #52 -- adaptive thinking

`ThinkingConfig` only had `Enabled { budget_tokens }` / `Disabled`. On Claude Opus 4.7, Opus 4.8, and Fable 5, `budget_tokens` returns **HTTP 400** -- `{"type": "adaptive"}` is the only accepted thinking mode, so the crate previously could not enable thinking on any current flagship (including its own `ModelId::OPUS_4_7`).

- Add `ThinkingConfig::Adaptive` (serializes to `{"type":"adaptive"}`) + `ThinkingConfig::adaptive()`.
- `Enabled { budget_tokens }` stays for Sonnet 4.6 and earlier Opus.
- Round-trip test + doc updates.

## #55 -- model constants

`ModelId` constants topped out at `OPUS_4_7`.

- Add `ModelId::OPUS_4_8` (`claude-opus-4-8`) and `ModelId::FABLE_5` (`claude-fable-5`).
- Round-trip tests; bump the README and `lib.rs` quick-start to `OPUS_4_8`.

`pricing.toml` is intentionally left untouched: I don't have verified per-MTok rates for Opus 4.8 / Fable 5, and shipping a wrong cost estimate is worse than the existing best-effort fallback (`cost_preview` falls back for unlisted models). Pricing entries can follow once rates are confirmed.

## Verification

Full CI mirror passes locally with `RUSTFLAGS="-D warnings"`: `fmt`, `clippy --all-features --all-targets`, `test --lib --tests` (default + all-features), the feature matrix, `doc`, and doctests.

Closes #52, closes #55.