### PR TITLE
feat(messages): output_config -- structured outputs, effort, task budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ namespace handle off [`Client`]:
 - **Tool dispatch** with `ToolRegistry`, parallel-by-default
   invocation, mid-stream approval gates, cumulative cost budget,
   cancellation token.
+- **Structured outputs**. `output_config.format` constrains the
+  response to a JSON Schema; `OutputFormat::from_schemars::<T>()`
+  derives the schema from a Rust type (under `schemars-tools`). The
+  same `output_config` carries reasoning `effort` and a beta
+  `task_budget`.
 - **`#[derive(Tool)]`** proc-macro generates the `Tool` impl from a
   struct's `JsonSchema` (under the `derive` feature).
 - **`Conversation`** multi-turn helper with cumulative usage and

--- a/crates/claude-api/src/beta.rs
+++ b/crates/claude-api/src/beta.rs
@@ -78,6 +78,8 @@ pub enum BetaHeader {
     UserProfiles,
     /// `advisor-tool-2026-03-01`
     AdvisorTool,
+    /// `task-budgets-2026-03-13`
+    TaskBudgets,
     /// Forward-compat fallback for beta headers added by Anthropic
     /// after this enum was last updated. Round-trips byte-for-byte.
     Other(String),
@@ -111,6 +113,7 @@ impl BetaHeader {
             Self::Output300k => "output-300k-2026-03-24",
             Self::UserProfiles => "user-profiles-2026-03-24",
             Self::AdvisorTool => "advisor-tool-2026-03-01",
+            Self::TaskBudgets => "task-budgets-2026-03-13",
             Self::Other(v) => v,
         }
     }
@@ -180,6 +183,7 @@ impl BetaHeader {
             "output-300k-2026-03-24" => Self::Output300k,
             "user-profiles-2026-03-24" => Self::UserProfiles,
             "advisor-tool-2026-03-01" => Self::AdvisorTool,
+            "task-budgets-2026-03-13" => Self::TaskBudgets,
             _ => return None,
         })
     }
@@ -203,7 +207,7 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
-    /// All 23 canonical wire strings, in the order they appear on the
+    /// All 24 canonical wire strings, in the order they appear on the
     /// API reference. Pin against drift.
     const ALL_WIRE: &[&str] = &[
         "message-batches-2024-09-24",
@@ -229,6 +233,7 @@ mod tests {
         "output-300k-2026-03-24",
         "user-profiles-2026-03-24",
         "advisor-tool-2026-03-01",
+        "task-budgets-2026-03-13",
     ];
 
     #[test]

--- a/crates/claude-api/src/messages/mod.rs
+++ b/crates/claude-api/src/messages/mod.rs
@@ -48,6 +48,8 @@
 //! - [`citation`] -- typed [`Citation`] enum
 //! - [`input`] -- [`MessageInput`], [`SystemPrompt`] helpers
 //! - [`metadata`] -- [`MessageMetadata`], [`RequestServiceTier`]
+//! - [`output`] -- [`OutputConfig`] (structured-output `format`, `effort`,
+//!   `task_budget`)
 //!
 //! For streaming, see [`stream`] for the wire-event types and
 //! [`api::Messages::create_stream`] for the namespace method.
@@ -58,6 +60,7 @@ pub mod content;
 pub mod input;
 pub mod mcp;
 pub mod metadata;
+pub mod output;
 pub mod request;
 pub mod response;
 pub mod stream;
@@ -76,6 +79,7 @@ pub use content::{
 pub use input::{MessageContent, MessageInput, SystemPrompt};
 pub use mcp::{McpServerConfig, McpToolConfiguration};
 pub use metadata::{MessageMetadata, RequestServiceTier};
+pub use output::{Effort, OutputConfig, OutputFormat, TaskBudget};
 pub use request::{
     CountTokensRequest, CountTokensRequestBuilder, CreateMessageRequest,
     CreateMessageRequestBuilder,

--- a/crates/claude-api/src/messages/output.rs
+++ b/crates/claude-api/src/messages/output.rs
@@ -1,0 +1,294 @@
+//! Output configuration for the Messages API (`output_config`).
+//!
+//! Bundles the three generation-shaping controls the API exposes under the
+//! top-level `output_config` object:
+//!
+//! - [`OutputFormat`] -- constrain the model's output to a JSON Schema
+//!   (structured outputs). GA; no beta header.
+//! - [`Effort`] -- how hard the model works before answering. GA; no beta
+//!   header.
+//! - [`TaskBudget`] -- an advisory token budget for an agentic loop. Beta:
+//!   requires the `task-budgets-2026-03-13` header via
+//!   [`ClientBuilder::beta`](crate::ClientBuilder::beta) (see
+//!   [`BetaHeader::TaskBudgets`](crate::BetaHeader::TaskBudgets)).
+//!
+//! ```no_run
+//! use claude_api::messages::{CreateMessageRequest, OutputFormat};
+//! use claude_api::types::ModelId;
+//! use serde_json::json;
+//!
+//! # fn main() -> Result<(), claude_api::Error> {
+//! let req = CreateMessageRequest::builder()
+//!     .model(ModelId::SONNET_4_6)
+//!     .max_tokens(1024)
+//!     .user("Extract the person's name and age from: Ada Lovelace, 36.")
+//!     .output_format(OutputFormat::json_schema(json!({
+//!         "type": "object",
+//!         "properties": {
+//!             "name": { "type": "string" },
+//!             "age": { "type": "integer" }
+//!         },
+//!         "required": ["name", "age"],
+//!         "additionalProperties": false
+//!     })))
+//!     .build()?;
+//! # Ok(()) }
+//! ```
+//!
+//! The schema-constrained JSON is returned in a normal `text` content block;
+//! parse it with `serde_json::from_str`. Structured outputs cannot be combined
+//! with citations or assistant prefill (the API returns 400).
+
+use serde::{Deserialize, Serialize};
+
+/// Generation-shaping options sent as the request's `output_config`.
+///
+/// Construct with [`OutputConfig::new`] and the `with_*` methods, or set the
+/// fields individually through the request builder
+/// ([`output_format`](crate::messages::CreateMessageRequestBuilder::output_format),
+/// [`effort`](crate::messages::CreateMessageRequestBuilder::effort),
+/// [`task_budget`](crate::messages::CreateMessageRequestBuilder::task_budget)).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct OutputConfig {
+    /// Constrain the model's output to a schema (structured outputs).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub format: Option<OutputFormat>,
+    /// Reasoning effort level.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<Effort>,
+    /// Advisory token budget for an agentic loop (beta).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_budget: Option<TaskBudget>,
+}
+
+impl OutputConfig {
+    /// An empty config. Equivalent to [`OutputConfig::default`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the output [`format`](Self::format).
+    #[must_use]
+    pub fn with_format(mut self, format: OutputFormat) -> Self {
+        self.format = Some(format);
+        self
+    }
+
+    /// Set the reasoning [`effort`](Self::effort).
+    #[must_use]
+    pub fn with_effort(mut self, effort: Effort) -> Self {
+        self.effort = Some(effort);
+        self
+    }
+
+    /// Set the [`task_budget`](Self::task_budget).
+    #[must_use]
+    pub fn with_task_budget(mut self, task_budget: TaskBudget) -> Self {
+        self.task_budget = Some(task_budget);
+        self
+    }
+}
+
+/// How the model's output should be formatted.
+///
+/// The API currently supports a single variant, `json_schema`, which
+/// constrains the response to valid JSON matching the supplied schema
+/// (structured outputs). Modeled as an enum so future format types round-trip
+/// without a breaking change.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum OutputFormat {
+    /// Constrain output to JSON matching `schema`.
+    JsonSchema {
+        /// The JSON Schema the output must satisfy. See the Anthropic
+        /// structured-outputs docs for the supported schema subset
+        /// (`additionalProperties: false` is required on every object).
+        schema: serde_json::Value,
+    },
+}
+
+impl OutputFormat {
+    /// Construct a [`OutputFormat::JsonSchema`] from a raw JSON Schema value.
+    #[must_use]
+    pub fn json_schema(schema: serde_json::Value) -> Self {
+        Self::JsonSchema { schema }
+    }
+
+    /// Construct a [`OutputFormat::JsonSchema`] whose schema is derived from a
+    /// Rust type via [`schemars`].
+    ///
+    /// # Panics
+    ///
+    /// Panics only if the generated `RootSchema` fails to JSON-serialize,
+    /// which `schemars` guarantees not to happen for any type that implements
+    /// [`schemars::JsonSchema`].
+    ///
+    /// ```ignore
+    /// # use claude_api::messages::OutputFormat;
+    /// #[derive(schemars::JsonSchema)]
+    /// struct Person { name: String, age: u32 }
+    ///
+    /// let format = OutputFormat::from_schemars::<Person>();
+    /// ```
+    #[cfg(feature = "schemars-tools")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "schemars-tools")))]
+    #[must_use]
+    pub fn from_schemars<T: schemars::JsonSchema>() -> Self {
+        let schema = schemars::r#gen::SchemaGenerator::default().into_root_schema_for::<T>();
+        let schema = serde_json::to_value(schema).expect("RootSchema is always JSON-serializable");
+        Self::JsonSchema { schema }
+    }
+}
+
+/// Reasoning effort: how hard the model works before producing output.
+///
+/// Higher levels spend more on reasoning. Defaults to [`Effort::High`] when
+/// omitted. [`Effort::XHigh`] is only accepted by some models (e.g. Fable 5,
+/// Opus 4.7+).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum Effort {
+    /// Minimal reasoning.
+    Low,
+    /// Moderate reasoning.
+    Medium,
+    /// Thorough reasoning (the default when `effort` is omitted).
+    High,
+    /// Extra-high reasoning. Only accepted by some models.
+    XHigh,
+    /// Maximum reasoning.
+    Max,
+}
+
+/// Advisory token budget for an agentic loop (beta).
+///
+/// Requires the `task-budgets-2026-03-13` beta header (see
+/// [`BetaHeader::TaskBudgets`](crate::BetaHeader::TaskBudgets)). The budget is
+/// a soft hint spanning the whole loop, not a hard per-request cap --
+/// `max_tokens` still bounds each individual response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum TaskBudget {
+    /// A budget measured in tokens.
+    Tokens {
+        /// Total token budget for the loop. The API requires at least 20,000.
+        total: u64,
+        /// Budget carried over from a prior request (used during compaction).
+        /// Defaults to `total` when omitted.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        remaining: Option<u64>,
+    },
+}
+
+impl TaskBudget {
+    /// A token budget with no carried-over `remaining`.
+    #[must_use]
+    pub fn tokens(total: u64) -> Self {
+        Self::Tokens {
+            total,
+            remaining: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    #[test]
+    fn json_schema_format_round_trips() {
+        let f = OutputFormat::json_schema(json!({"type": "object"}));
+        let v = serde_json::to_value(&f).unwrap();
+        assert_eq!(
+            v,
+            json!({"type": "json_schema", "schema": {"type": "object"}})
+        );
+        let parsed: OutputFormat = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed, f);
+    }
+
+    #[test]
+    fn effort_serializes_lowercase() {
+        for (variant, wire) in [
+            (Effort::Low, "low"),
+            (Effort::Medium, "medium"),
+            (Effort::High, "high"),
+            (Effort::XHigh, "xhigh"),
+            (Effort::Max, "max"),
+        ] {
+            let v = serde_json::to_value(variant).unwrap();
+            assert_eq!(v, json!(wire));
+            let parsed: Effort = serde_json::from_value(v).unwrap();
+            assert_eq!(parsed, variant);
+        }
+    }
+
+    #[test]
+    fn task_budget_round_trips() {
+        let b = TaskBudget::tokens(20_000);
+        assert_eq!(
+            serde_json::to_value(b).unwrap(),
+            json!({"type": "tokens", "total": 20_000})
+        );
+
+        let with_remaining = TaskBudget::Tokens {
+            total: 64_000,
+            remaining: Some(1_000),
+        };
+        let v = serde_json::to_value(with_remaining).unwrap();
+        assert_eq!(
+            v,
+            json!({"type": "tokens", "total": 64_000, "remaining": 1_000})
+        );
+        let parsed: TaskBudget = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed, with_remaining);
+    }
+
+    #[test]
+    fn empty_output_config_serializes_to_empty_object() {
+        assert_eq!(
+            serde_json::to_value(OutputConfig::new()).unwrap(),
+            json!({})
+        );
+    }
+
+    #[test]
+    fn full_output_config_round_trips() {
+        let cfg = OutputConfig::new()
+            .with_format(OutputFormat::json_schema(json!({"type": "object"})))
+            .with_effort(Effort::High)
+            .with_task_budget(TaskBudget::tokens(20_000));
+        let v = serde_json::to_value(&cfg).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "format": {"type": "json_schema", "schema": {"type": "object"}},
+                "effort": "high",
+                "task_budget": {"type": "tokens", "total": 20_000}
+            })
+        );
+        let parsed: OutputConfig = serde_json::from_value(v).unwrap();
+        assert_eq!(parsed, cfg);
+    }
+
+    #[cfg(feature = "schemars-tools")]
+    #[test]
+    fn from_schemars_builds_json_schema() {
+        #[derive(schemars::JsonSchema)]
+        #[allow(dead_code)]
+        struct Person {
+            name: String,
+            age: u32,
+        }
+        let OutputFormat::JsonSchema { schema } = OutputFormat::from_schemars::<Person>();
+        assert!(schema.is_object());
+        assert_eq!(schema["type"], json!("object"));
+    }
+}

--- a/crates/claude-api/src/messages/request.rs
+++ b/crates/claude-api/src/messages/request.rs
@@ -33,6 +33,7 @@ fn apply_cache_control_to_last_block_with(blocks: &mut [ContentBlock], cc: Cache
 }
 use crate::messages::mcp::McpServerConfig;
 use crate::messages::metadata::{MessageMetadata, RequestServiceTier};
+use crate::messages::output::{Effort, OutputConfig, OutputFormat, TaskBudget};
 use crate::messages::thinking::ThinkingConfig;
 use crate::messages::tools::{Tool, ToolChoice};
 use crate::types::ModelId;
@@ -91,6 +92,10 @@ pub struct CreateMessageRequest {
     /// Container ID for the code-execution built-in tool.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub container: Option<String>,
+    /// Output configuration: structured-output `format`, reasoning `effort`,
+    /// and `task_budget`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_config: Option<OutputConfig>,
 
     /// Whether to stream the response. Set internally by `create_stream`;
     /// not normally touched by callers.
@@ -125,6 +130,7 @@ pub struct CreateMessageRequestBuilder {
     thinking: Option<ThinkingConfig>,
     mcp_servers: Vec<McpServerConfig>,
     container: Option<String>,
+    output_config: Option<OutputConfig>,
 }
 
 impl CreateMessageRequestBuilder {
@@ -372,6 +378,49 @@ impl CreateMessageRequestBuilder {
         self
     }
 
+    /// Set the full [`OutputConfig`] -- structured-output `format`, reasoning
+    /// `effort`, and `task_budget`.
+    #[must_use]
+    pub fn output_config(mut self, cfg: OutputConfig) -> Self {
+        self.output_config = Some(cfg);
+        self
+    }
+
+    /// Constrain the model's output to a schema (structured outputs).
+    ///
+    /// Convenience for setting [`OutputConfig::format`].
+    #[must_use]
+    pub fn output_format(mut self, format: OutputFormat) -> Self {
+        self.output_config
+            .get_or_insert_with(OutputConfig::default)
+            .format = Some(format);
+        self
+    }
+
+    /// Set the reasoning effort level.
+    ///
+    /// Convenience for setting [`OutputConfig::effort`].
+    #[must_use]
+    pub fn effort(mut self, effort: Effort) -> Self {
+        self.output_config
+            .get_or_insert_with(OutputConfig::default)
+            .effort = Some(effort);
+        self
+    }
+
+    /// Set the agentic task budget.
+    ///
+    /// Convenience for setting [`OutputConfig::task_budget`]. Requires the
+    /// `task-budgets-2026-03-13` beta header on the client (see
+    /// [`BetaHeader::TaskBudgets`](crate::BetaHeader::TaskBudgets)).
+    #[must_use]
+    pub fn task_budget(mut self, budget: TaskBudget) -> Self {
+        self.output_config
+            .get_or_insert_with(OutputConfig::default)
+            .task_budget = Some(budget);
+        self
+    }
+
     /// Finalize the request.
     ///
     /// # Errors
@@ -401,6 +450,7 @@ impl CreateMessageRequestBuilder {
             thinking: self.thinking,
             mcp_servers: self.mcp_servers,
             container: self.container,
+            output_config: self.output_config,
             stream: false,
         })
     }
@@ -632,6 +682,25 @@ mod tests {
             v.get("stream").is_none(),
             "stream must be omitted when false"
         );
+    }
+
+    #[test]
+    fn output_config_serializes_under_output_config_key() {
+        let req = CreateMessageRequest::builder()
+            .model(ModelId::SONNET_4_6)
+            .max_tokens(256)
+            .user("extract")
+            .output_format(OutputFormat::json_schema(json!({"type": "object"})))
+            .effort(Effort::High)
+            .build()
+            .unwrap();
+        let v = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["output_config"]["format"]["type"], "json_schema");
+        assert_eq!(
+            v["output_config"]["format"]["schema"],
+            json!({"type": "object"})
+        );
+        assert_eq!(v["output_config"]["effort"], "high");
     }
 
     #[test]


### PR DESCRIPTION
Adds the Messages-API `output_config` object, covering the three generation-shaping controls the API exposes under one key.

## #53 -- structured outputs

- `OutputFormat::JsonSchema { schema }` constrains the response to a JSON Schema. GA; no beta header. Returned in a normal `text` block (parse with `serde_json::from_str`).
- `OutputFormat::json_schema(value)` for a raw schema, and `OutputFormat::from_schemars::<T>()` (under `schemars-tools`) to derive the schema from a Rust type -- mirrors `Tool::from_schemars`.

## #54 -- effort + task budget

- `Effort` (`low`/`medium`/`high`/`xhigh`/`max`), GA. Defaults to `high` server-side; only serialized when set.
- `TaskBudget::Tokens { total, remaining? }` advisory agentic budget. Beta -- adds `BetaHeader::TaskBudgets` (`task-budgets-2026-03-13`), which the caller sets on the client via `.beta(...)` (consistent with how every other beta is wired here).

## API

```rust
let req = CreateMessageRequest::builder()
    .model(ModelId::SONNET_4_6)
    .max_tokens(1024)
    .user("...")
    .output_format(OutputFormat::from_schemars::<Person>()) // or .json_schema(json!(...))
    .effort(Effort::High)
    .build()?;
```

Builder gains `.output_config` / `.output_format` / `.effort` / `.task_budget`; the field is omitted from the wire payload when unset. Per the docs, structured outputs cannot combine with citations or assistant prefill (the API returns 400) -- noted in the module docs, not enforced (transport stays permissive).

Shapes verified against current Anthropic docs (`platform.claude.com`): `output_config.{format,effort,task_budget}`, `format` carries only `type`+`schema` (no `name`/`strict`).

## Verification

Full CI mirror passes locally with `RUSTFLAGS="-D warnings"`: fmt, clippy `--all-features --all-targets`, tests (default + all-features), `--no-default-features`, doc, and doctests. New round-trip + request-level tests included.

## Notes

Branched off `main`, independent of #59. Examples use `ModelId::SONNET_4_6` (the `OPUS_4_8` constant lands in #59); can bump once that merges.

Closes #53, closes #54.