### PR TITLE
docs: correct vertex feature note + sampling-param model notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ namespace handle off [`Client`]:
 | `pricing` |  | `PricingTable` + cost calculation + `cost_preview` |
 | `conversation` |  | Multi-turn `Conversation` helper |
 | `bedrock` |  | AWS sigv4 `BedrockSigner` |
-| `vertex` |  | (placeholder, not yet wired -- see [#6](https://github.com/joshrotenberg/claude-api/issues/6)) |
+| `vertex` |  | GCP Vertex auth via `VertexSigner`; typed `.vertex()` namespace tracked in [#42](https://github.com/joshrotenberg/claude-api/issues/42) |
 | `admin` |  | Admin API |
 | `skills` |  | Skills API |
 | `user-profiles` |  | User Profiles API |

--- a/crates/claude-api/src/messages/request.rs
+++ b/crates/claude-api/src/messages/request.rs
@@ -185,6 +185,11 @@ impl CreateMessageRequestBuilder {
     }
 
     /// Set the sampling temperature.
+    ///
+    /// Note: Claude Opus 4.7+ and Fable 5 reject `temperature`, `top_p`, and
+    /// `top_k` with HTTP 400 -- those models do not accept sampling
+    /// parameters. The crate forwards the value as-is rather than dropping it,
+    /// so the API surfaces the error.
     #[must_use]
     pub fn temperature(mut self, t: f32) -> Self {
         self.temperature = Some(t);
@@ -192,6 +197,8 @@ impl CreateMessageRequestBuilder {
     }
 
     /// Set the nucleus sampling cutoff.
+    ///
+    /// See [`Self::temperature`] -- rejected by Claude Opus 4.7+ and Fable 5.
     #[must_use]
     pub fn top_p(mut self, p: f32) -> Self {
         self.top_p = Some(p);
@@ -199,6 +206,8 @@ impl CreateMessageRequestBuilder {
     }
 
     /// Set the top-k sampling cutoff.
+    ///
+    /// See [`Self::temperature`] -- rejected by Claude Opus 4.7+ and Fable 5.
     #[must_use]
     pub fn top_k(mut self, k: u32) -> Self {
         self.top_k = Some(k);


### PR DESCRIPTION
Two small documentation fixes.

## #56 -- vertex feature note

The README feature-flag table called `vertex` a "placeholder, not yet wired -- see #6", but `VertexSigner` (GCP Vertex auth) shipped in #37 and #6 is closed. Updated the row to reflect that the signer exists and the remaining work -- the typed `.vertex()` namespace -- is tracked in #42.

## #57 -- sampling-parameter notes

`temperature`, `top_p`, and `top_k` return HTTP 400 on Claude Opus 4.7+ and Fable 5, which don't accept sampling parameters. Documented this on the three builder setters. Resolved as docs-only: the crate forwards the values as-is (transport stays permissive) so the API surfaces the error, rather than silently dropping them.

## Verification

fmt, clippy `--all-features --all-targets`, doc (`-D warnings`, intra-doc links resolve), and tests all pass.

Branched off `main`, independent of the other open PRs.

Closes #56, closes #57.